### PR TITLE
fix: persist CalDAV UID to markdown frontmatter after push

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -121,6 +121,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			msg.Task.CalDAVUID = msg.UID
 			a.syncBack(msg.Task)
+			// Persist UID to frontmatter for single-task files
+			_ = vault.WriteFrontmatterUID(msg.Task.Source.FilePath, msg.UID)
 			a.refreshSections()
 			a.message = "Pushed to CalDAV: " + msg.Task.Description
 		}
@@ -300,6 +302,8 @@ func (a App) handlePushFormKey(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				t.CalDAVUID = uid
 				a.syncBack(t)
+				// Persist UID to frontmatter for single-task files
+				_ = vault.WriteFrontmatterUID(t.Source.FilePath, uid)
 				a.message = "Pushed to CalDAV: " + t.Description
 			}
 		}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -65,6 +65,7 @@ func AddTaskWithAutoPushCmd(filePath, description string, caldavCfg config.CalDA
 					AutoPushErr: pushErr,
 				}
 			}
+			_ = vault.WriteFrontmatterUID(filePath, uid)
 			return TaskAddedMsg{
 				Description: description,
 				AutoPushUID: uid,

--- a/internal/vault/parser.go
+++ b/internal/vault/parser.go
@@ -143,8 +143,9 @@ func extractTags(s string) []string {
 }
 
 type frontmatterData struct {
-	calDAVUID string
-	due       *time.Time
+	calDAVUID  string
+	due        *time.Time
+	isTaskFile bool // true if frontmatter contains "type: task"
 }
 
 func parseFrontmatter(f *os.File) frontmatterData {
@@ -175,6 +176,10 @@ func parseFrontmatter(f *os.File) frontmatterData {
 				data.due = &t
 			} else if t, err := time.Parse(time.RFC3339, value); err == nil {
 				data.due = &t
+			}
+		case "type":
+			if value == "task" {
+				data.isTaskFile = true
 			}
 		}
 	}

--- a/internal/vault/writer.go
+++ b/internal/vault/writer.go
@@ -87,6 +87,61 @@ func ResolveTaskFile(vaultPath, dailyFolder, dailyFormat, defaultFile, target st
 	return dailyPath
 }
 
+// WriteFrontmatterUID writes caldav-uid to the YAML frontmatter of filePath,
+// but only if the file has frontmatter containing "type: task".
+// Multi-task files (daily notes, todo.md) are skipped — returns nil.
+func WriteFrontmatterUID(filePath, uid string) error {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", filePath, err)
+	}
+
+	content := string(data)
+	lines := strings.Split(content, "\n")
+
+	// Must start with ---
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return nil
+	}
+
+	// Find the closing --- and check for "type: task"
+	closingIdx := -1
+	isTaskFile := false
+	for i := 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "---" {
+			closingIdx = i
+			break
+		}
+		key, value, ok := parseYAMLLine(trimmed)
+		if ok && key == "type" && value == "task" {
+			isTaskFile = true
+		}
+	}
+
+	// No closing --- found or not a single-task file
+	if closingIdx < 0 || !isTaskFile {
+		return nil
+	}
+
+	// Check if caldav-uid already exists in the frontmatter
+	for i := 1; i < closingIdx; i++ {
+		key, _, ok := parseYAMLLine(strings.TrimSpace(lines[i]))
+		if ok && key == "caldav-uid" {
+			// Replace existing value
+			lines[i] = "caldav-uid: " + uid
+			return os.WriteFile(filePath, []byte(strings.Join(lines, "\n")), 0o644)
+		}
+	}
+
+	// Insert before closing ---
+	newLines := make([]string, 0, len(lines)+1)
+	newLines = append(newLines, lines[:closingIdx]...)
+	newLines = append(newLines, "caldav-uid: "+uid)
+	newLines = append(newLines, lines[closingIdx:]...)
+	return os.WriteFile(filePath, []byte(strings.Join(newLines, "\n")), 0o644)
+}
+
 // AppendTask adds a new task line to the given file.
 func AppendTask(filePath string, description string) error {
 	_, err := AppendTaskAt(filePath, description)

--- a/internal/vault/writer_test.go
+++ b/internal/vault/writer_test.go
@@ -204,3 +204,71 @@ func TestAppendTaskAt_NewFile(t *testing.T) {
 		t.Errorf("expected line 2, got %d", line)
 	}
 }
+
+func TestWriteFrontmatterUID_SingleTaskFile(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "task.md")
+	content := "---\ntype: task\ndue: 2026-04-01\n---\n\n- [ ] Do the thing\n"
+	os.WriteFile(f, []byte(content), 0o644)
+
+	if err := WriteFrontmatterUID(f, "abc-123"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(f)
+	if !strings.Contains(string(data), "caldav-uid: abc-123") {
+		t.Errorf("expected caldav-uid in file, got:\n%s", string(data))
+	}
+}
+
+func TestWriteFrontmatterUID_UpdatesExisting(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "task.md")
+	content := "---\ntype: task\ncaldav-uid: old-uid\n---\n\n- [ ] Do the thing\n"
+	os.WriteFile(f, []byte(content), 0o644)
+
+	if err := WriteFrontmatterUID(f, "new-uid"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(f)
+	result := string(data)
+	if !strings.Contains(result, "caldav-uid: new-uid") {
+		t.Errorf("expected updated caldav-uid, got:\n%s", result)
+	}
+	if strings.Contains(result, "old-uid") {
+		t.Errorf("expected old-uid to be replaced, got:\n%s", result)
+	}
+}
+
+func TestWriteFrontmatterUID_SkipsMultiTaskFile(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "todo.md")
+	content := "---\ntitle: My Todo List\n---\n\n- [ ] Task one\n- [ ] Task two\n"
+	os.WriteFile(f, []byte(content), 0o644)
+
+	if err := WriteFrontmatterUID(f, "some-uid"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(f)
+	if strings.Contains(string(data), "caldav-uid") {
+		t.Errorf("expected no caldav-uid written to multi-task file, got:\n%s", string(data))
+	}
+}
+
+func TestWriteFrontmatterUID_SkipsNoFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "plain.md")
+	content := "# Plain Note\n\n- [ ] Task without frontmatter\n"
+	os.WriteFile(f, []byte(content), 0o644)
+
+	if err := WriteFrontmatterUID(f, "some-uid"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(f)
+	if strings.Contains(string(data), "caldav-uid") {
+		t.Errorf("expected no caldav-uid written to file without frontmatter, got:\n%s", string(data))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `vault.WriteFrontmatterUID(filePath, uid)` that writes `caldav-uid` to YAML frontmatter after a successful CalDAV push
- Only writes for single-task files (frontmatter contains `type: task`) — multi-task files like `todo.md` and daily notes are skipped
- Called after every successful push: manual push via `p` key and auto-push on task add
- Adds `isTaskFile bool` to `frontmatterData` in parser for `type: task` detection
- Enables full interop with the Obsidian CalDAV plugin which reads `caldav-uid` from frontmatter

## Fixes

Closes #7

## Test plan

- [ ] `go test ./internal/vault/` passes
- [ ] `go test ./...` passes
- [ ] Single-task file (has `type: task` frontmatter) gets `caldav-uid` written after push
- [ ] `todo.md` and daily notes are not modified on push