### PR TITLE
feat: rich add-task form with target picker, due date, CalDAV metadata

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,11 +9,12 @@ import (
 )
 
 type Vault struct {
-	Path             string `toml:"path"`
-	DailyNotesFolder string `toml:"daily_notes_folder"`
-	DailyNotesFormat string `toml:"daily_notes_format"`
-	DefaultTaskFile  string `toml:"default_task_file"`
-	AddTaskTarget    string `toml:"add_task_target"` // "daily" | "default"
+	Path             string   `toml:"path"`
+	DailyNotesFolder string   `toml:"daily_notes_folder"`
+	DailyNotesFormat string   `toml:"daily_notes_format"`
+	DefaultTaskFile  string   `toml:"default_task_file"`
+	AddTaskTarget    string   `toml:"add_task_target"` // "daily" | "default" | vault-relative path
+	ExtraTargets     []string `toml:"extra_targets"`   // additional vault-relative paths
 }
 
 type CalDAV struct {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hawkaii/obia/internal/caldav"
 	"github.com/hawkaii/obia/internal/config"
 	"github.com/hawkaii/obia/internal/task"
+	"github.com/hawkaii/obia/internal/tui/components/addform"
 	"github.com/hawkaii/obia/internal/tui/components/pushform"
 	"github.com/hawkaii/obia/internal/vault"
 	appctx "github.com/hawkaii/obia/internal/tui/context"
@@ -23,6 +24,7 @@ type appMode int
 const (
 	modeBrowser appMode = iota
 	modePushForm
+	modeAddForm
 	// modeChat — future
 )
 
@@ -32,7 +34,6 @@ type inputMode int
 const (
 	inputNone inputMode = iota
 	inputFilter
-	inputAddTask
 )
 
 type App struct {
@@ -50,6 +51,7 @@ type App struct {
 	cursor    int
 	loading   bool
 	pushForm  pushform.Model
+	addForm   addform.Model
 }
 
 func NewApp(cfg config.Config) App {
@@ -107,11 +109,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Err != nil {
 			a.message = "Error: " + msg.Err.Error()
 		} else if msg.AutoPushErr != nil {
-			a.message = "Added: " + msg.Description + " (CalDAV push failed: " + msg.AutoPushErr.Error() + ")"
+			a.message = "Task added · CalDAV push failed: " + msg.AutoPushErr.Error()
 		} else if msg.AutoPushUID != "" {
-			a.message = "Added + pushed to CalDAV: " + msg.Description
+			a.message = "Task added · pushed to CalDAV"
 		} else {
-			a.message = "Added: " + msg.Description
+			a.message = "Task added"
 		}
 		return a, LoadTasksCmd(a.ctx.VaultPath())
 
@@ -131,10 +133,15 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.handleKey(msg)
 	}
 
-	// Delegate non-key messages to push form for cursor blink etc.
+	// Delegate non-key messages to active form for cursor blink etc.
 	if a.mode == modePushForm {
 		var cmd tea.Cmd
 		a.pushForm, cmd = a.pushForm.Update(msg)
+		return a, cmd
+	}
+	if a.mode == modeAddForm {
+		var cmd tea.Cmd
+		a.addForm, cmd = a.addForm.Update(msg)
 		return a, cmd
 	}
 
@@ -142,14 +149,15 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (a App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if a.mode == modePushForm {
+	switch a.mode {
+	case modePushForm:
 		return a.handlePushFormKey(msg)
+	case modeAddForm:
+		return a.handleAddFormKey(msg)
 	}
 	switch a.inputMode {
 	case inputFilter:
 		return a.handleFilterKey(msg)
-	case inputAddTask:
-		return a.handleAddTaskKey(msg)
 	default:
 		return a.handleBrowserKey(msg)
 	}
@@ -201,8 +209,11 @@ func (a App) handleBrowserKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case key.Matches(msg, a.keys.AddTask):
-		a.inputMode = inputAddTask
-		a.input = ""
+		targets, defaultIdx := buildTargets(a.ctx.Config)
+		showPush := a.ctx.Config.CalDAV.URL != ""
+		defaultPush := a.ctx.Config.CalDAV.AutoPush
+		a.addForm = addform.New(targets, defaultIdx, defaultPush, showPush)
+		a.mode = modeAddForm
 		return a, nil
 
 	case key.Matches(msg, a.keys.Push):
@@ -250,31 +261,43 @@ func (a App) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return a, nil
 }
 
-func (a App) handleAddTaskKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch {
-	case key.Matches(msg, a.keys.Enter):
-		if a.input != "" {
-			cfg := a.ctx.Config.Vault
-			filePath := vault.ResolveTaskFile(cfg.Path, cfg.DailyNotesFolder, cfg.DailyNotesFormat, cfg.DefaultTaskFile, cfg.AddTaskTarget)
-			desc := a.input
-			a.input = ""
-			a.inputMode = inputNone
-			return a, AddTaskWithAutoPushCmd(filePath, desc, a.ctx.Config.CalDAV)
-		}
-		a.inputMode = inputNone
-	case key.Matches(msg, a.keys.Escape):
-		a.input = ""
-		a.inputMode = inputNone
-	case key.Matches(msg, a.keys.Backspace):
-		if len(a.input) > 0 {
-			a.input = a.input[:len(a.input)-1]
-		}
-	default:
-		if len(msg.Runes) > 0 {
-			a.input += string(msg.Runes)
+func (a App) handleAddFormKey(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	a.addForm, cmd = a.addForm.Update(msg)
+
+	if a.addForm.Cancelled() {
+		a.mode = modeBrowser
+		a.message = ""
+		return a, nil
+	}
+
+	if a.addForm.Submitted() {
+		cfg := a.ctx.Config.Vault
+		target := a.addForm.GetTarget()
+		filePath := vault.ResolveTaskFile(cfg.Path, cfg.DailyNotesFolder, cfg.DailyNotesFormat, cfg.DefaultTaskFile, target)
+		summary := a.addForm.GetSummary()
+		due := a.addForm.GetDue()
+		priority := a.addForm.GetPriority()
+		status := a.addForm.GetStatus()
+		push := a.addForm.GetPush()
+		a.mode = modeBrowser
+		return a, AddTaskWithMetaCmd(filePath, summary, due, priority, status, push, a.ctx.Config.CalDAV)
+	}
+
+	return a, cmd
+}
+
+// buildTargets returns the ordered list of routing targets and the index of the default.
+func buildTargets(cfg config.Config) ([]string, int) {
+	targets := append([]string{"daily", "default"}, cfg.Vault.ExtraTargets...)
+	defaultIdx := 0
+	for i, t := range targets {
+		if t == cfg.Vault.AddTaskTarget {
+			defaultIdx = i
+			break
 		}
 	}
-	return a, nil
+	return targets, defaultIdx
 }
 
 func (a App) handlePushFormKey(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -383,14 +406,16 @@ func (a App) View() string {
 		b.WriteString(a.activeSection().View(w, listHeight, a.cursor, true))
 	}
 
-	// Input line
+	// Input line / overlay forms
 	if a.inputMode == inputFilter {
 		b.WriteString(filterPromptStyle.Render("/") + a.input + "█\n")
-	} else if a.inputMode == inputAddTask {
-		b.WriteString(filterPromptStyle.Render("add: ") + a.input + "█\n")
 	} else if a.mode == modePushForm {
 		b.WriteString("\n")
 		b.WriteString(a.pushForm.View())
+		b.WriteString("\n")
+	} else if a.mode == modeAddForm {
+		b.WriteString("\n")
+		b.WriteString(a.addForm.View())
 		b.WriteString("\n")
 	}
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/hawkaii/obia/internal/caldav"
 	"github.com/hawkaii/obia/internal/config"
@@ -40,16 +42,16 @@ func PushCalDAVCmd(cfg config.CalDAV, t *task.Task) tea.Cmd {
 	}
 }
 
-// AddTaskWithAutoPushCmd appends a task and optionally pushes to CalDAV if auto_push is enabled.
-func AddTaskWithAutoPushCmd(filePath, description string, caldavCfg config.CalDAV) tea.Cmd {
+// AddTaskWithMetaCmd appends a task and optionally pushes to CalDAV with full metadata.
+// push=true performs the CalDAV push; push=false skips it regardless of caldavCfg.AutoPush.
+func AddTaskWithMetaCmd(filePath, description string, due *time.Time, priority int, status string, push bool, caldavCfg config.CalDAV) tea.Cmd {
 	return func() tea.Msg {
 		line, err := vault.AppendTaskAt(filePath, description)
 		if err != nil {
 			return TaskAddedMsg{Description: description, Err: err}
 		}
 
-		// Auto-push if configured
-		if caldavCfg.AutoPush && caldavCfg.URL != "" {
+		if push && caldavCfg.URL != "" {
 			t := &task.Task{
 				Description: description,
 				Source: task.Source{
@@ -57,11 +59,10 @@ func AddTaskWithAutoPushCmd(filePath, description string, caldavCfg config.CalDA
 					Line:     line,
 				},
 			}
-			uid, pushErr := caldav.PushTask(caldavCfg, t, nil, 0, "")
+			uid, pushErr := caldav.PushTask(caldavCfg, t, due, priority, status)
 			if pushErr != nil {
 				return TaskAddedMsg{
 					Description: description,
-					Err:         nil,
 					AutoPushErr: pushErr,
 				}
 			}

--- a/internal/tui/components/addform/model.go
+++ b/internal/tui/components/addform/model.go
@@ -1,0 +1,513 @@
+package addform
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/sahilm/fuzzy"
+)
+
+var (
+	priorityOptions = []string{"none", "1 (highest)", "5 (normal)", "9 (lowest)"}
+	priorityValues  = []int{0, 1, 5, 9}
+	statusOptions   = []string{"NEEDS-ACTION", "IN-PROCESS", "COMPLETED", "CANCELLED"}
+	pushOptions     = []string{"No", "Yes"}
+
+	formStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("170")).
+			Padding(1, 2).
+			Width(60)
+
+	labelStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("170")).
+			Bold(true).
+			Width(12)
+
+	activeFieldStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("170"))
+
+	inactiveFieldStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("245"))
+
+	titleFormStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("170")).
+			MarginBottom(1)
+
+	hintStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241")).
+			MarginTop(1)
+
+	pickerActiveStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("170")).
+				Bold(true)
+
+	pickerItemStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("245"))
+
+	pickerBoxStyle = lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder()).
+			BorderForeground(lipgloss.Color("240")).
+			Padding(0, 1).
+			Width(44)
+
+	ctrlXHintStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("214")).
+			Italic(true)
+)
+
+const pickerMaxVisible = 5
+
+// Model is the add task form component.
+type Model struct {
+	summary     textinput.Model
+	targetInput textinput.Model // fuzzy filter for target picker
+	targets     []string        // ["daily", "default", ...extra]
+	targetSel   int             // confirmed selection index
+	pickerIdx   []int           // filtered indices into targets
+	pickerCur   int             // cursor within pickerIdx
+	pickerOff   int             // scroll offset
+	ctrlXMode   bool            // waiting for chord second key
+	due         textinput.Model
+	priority    int  // index into priorityOptions
+	status      int  // index into statusOptions
+	push        int  // 0=No, 1=Yes
+	showPush    bool // false when CalDAV URL is empty
+	focusIndex  int  // 0=summary 1=target 2=due 3=priority 4=status [5=push]
+	submitted   bool
+	cancelled   bool
+}
+
+// New creates a new add form.
+func New(targets []string, defaultTargetIdx int, defaultPush bool, showPush bool) Model {
+	summary := textinput.New()
+	summary.Placeholder = "Task description"
+	summary.Focus()
+	summary.CharLimit = 200
+	summary.Width = 40
+
+	targetInput := textinput.New()
+	targetInput.Placeholder = "type to filter..."
+	targetInput.CharLimit = 80
+	targetInput.Width = 40
+
+	due := textinput.New()
+	due.Placeholder = "YYYY-MM-DD"
+	due.CharLimit = 10
+	due.Width = 40
+	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+	due.SetValue(tomorrow)
+
+	pushVal := 0
+	if defaultPush {
+		pushVal = 1
+	}
+
+	m := Model{
+		summary:     summary,
+		targetInput: targetInput,
+		targets:     targets,
+		targetSel:   defaultTargetIdx,
+		due:         due,
+		priority:    0,
+		status:      0,
+		push:        pushVal,
+		showPush:    showPush,
+		focusIndex:  0,
+	}
+	m.rebuildPicker()
+	return m
+}
+
+// rebuildPicker refilters targets based on current targetInput value.
+func (m *Model) rebuildPicker() {
+	filter := m.targetInput.Value()
+	if filter == "" {
+		m.pickerIdx = make([]int, len(m.targets))
+		for i := range m.targets {
+			m.pickerIdx[i] = i
+		}
+	} else {
+		matches := fuzzy.Find(filter, m.targets)
+		m.pickerIdx = make([]int, len(matches))
+		for i, match := range matches {
+			m.pickerIdx[i] = match.Index
+		}
+	}
+	if m.pickerCur >= len(m.pickerIdx) {
+		m.pickerCur = max(0, len(m.pickerIdx)-1)
+	}
+	m.syncPickerOffset()
+}
+
+func (m *Model) syncPickerOffset() {
+	if m.pickerCur < m.pickerOff {
+		m.pickerOff = m.pickerCur
+	}
+	if m.pickerCur >= m.pickerOff+pickerMaxVisible {
+		m.pickerOff = m.pickerCur - pickerMaxVisible + 1
+	}
+}
+
+func (m *Model) numFields() int {
+	if m.showPush {
+		return 6
+	}
+	return 5
+}
+
+func (m *Model) updateFocus() {
+	m.summary.Blur()
+	m.targetInput.Blur()
+	m.due.Blur()
+
+	switch m.focusIndex {
+	case 0:
+		m.summary.Focus()
+	case 1:
+		m.targetInput.Focus()
+	case 2:
+		m.due.Focus()
+	}
+}
+
+// confirmTargetSelection locks in the currently highlighted picker item.
+func (m *Model) confirmTargetSelection() {
+	if len(m.pickerIdx) > 0 && m.pickerCur < len(m.pickerIdx) {
+		m.targetSel = m.pickerIdx[m.pickerCur]
+	}
+}
+
+// selectTargetByName finds the first target matching name and selects it.
+func (m *Model) selectTargetByName(name string) {
+	for i, t := range m.targets {
+		if t == name {
+			m.targetSel = i
+			// Reset picker cursor to this item
+			for j, idx := range m.pickerIdx {
+				if idx == i {
+					m.pickerCur = j
+					m.syncPickerOffset()
+					break
+				}
+			}
+			return
+		}
+	}
+}
+
+// Update handles messages for the add form.
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		k := msg.String()
+
+		// Handle ctrl+x chord mode
+		if m.ctrlXMode {
+			m.ctrlXMode = false
+			switch k {
+			case "d":
+				m.selectTargetByName("daily")
+			case "t":
+				m.selectTargetByName("default")
+			}
+			return m, nil
+		}
+
+		// Global shortcuts
+		switch k {
+		case "esc":
+			m.cancelled = true
+			return m, nil
+		}
+
+		// y/n Push shortcuts when not in a text input field
+		if m.showPush && m.focusIndex != 0 && m.focusIndex != 1 && m.focusIndex != 2 {
+			switch k {
+			case "y":
+				m.push = 1
+				return m, nil
+			case "n":
+				m.push = 0
+				return m, nil
+			}
+		}
+
+		switch k {
+		case "tab":
+			if m.focusIndex == 1 {
+				m.confirmTargetSelection()
+			}
+			m.focusIndex = (m.focusIndex + 1) % m.numFields()
+			m.updateFocus()
+			return m, nil
+
+		case "shift+tab":
+			if m.focusIndex == 1 {
+				m.confirmTargetSelection()
+			}
+			m.focusIndex = (m.focusIndex - 1 + m.numFields()) % m.numFields()
+			m.updateFocus()
+			return m, nil
+
+		case "enter":
+			if m.focusIndex == 0 {
+				// Fast path: submit immediately from summary
+				if m.summary.Value() != "" {
+					m.submitted = true
+				}
+				return m, nil
+			}
+			if m.focusIndex == 1 {
+				// Confirm target and advance to Due
+				m.confirmTargetSelection()
+				m.focusIndex = 2
+				m.updateFocus()
+				return m, nil
+			}
+			// All other fields: submit
+			if m.summary.Value() != "" {
+				m.submitted = true
+			}
+			return m, nil
+
+		case "left", "right":
+			switch m.focusIndex {
+			case 3:
+				if k == "right" {
+					m.priority = (m.priority + 1) % len(priorityOptions)
+				} else {
+					m.priority = (m.priority - 1 + len(priorityOptions)) % len(priorityOptions)
+				}
+				return m, nil
+			case 4:
+				if k == "right" {
+					m.status = (m.status + 1) % len(statusOptions)
+				} else {
+					m.status = (m.status - 1 + len(statusOptions)) % len(statusOptions)
+				}
+				return m, nil
+			case 5:
+				if k == "right" {
+					m.push = (m.push + 1) % len(pushOptions)
+				} else {
+					m.push = (m.push - 1 + len(pushOptions)) % len(pushOptions)
+				}
+				return m, nil
+			}
+		}
+
+		// Target picker navigation
+		if m.focusIndex == 1 {
+			switch k {
+			case "ctrl+x":
+				m.ctrlXMode = true
+				return m, nil
+			case "ctrl+n", "down":
+				if m.pickerCur < len(m.pickerIdx)-1 {
+					m.pickerCur++
+					m.syncPickerOffset()
+				}
+				return m, nil
+			case "ctrl+p", "up":
+				if m.pickerCur > 0 {
+					m.pickerCur--
+					m.syncPickerOffset()
+				}
+				return m, nil
+			default:
+				// Delegate typing to targetInput
+				var cmd tea.Cmd
+				m.targetInput, cmd = m.targetInput.Update(msg)
+				m.rebuildPicker()
+				return m, cmd
+			}
+		}
+
+		// Delegate text input
+		var cmd tea.Cmd
+		switch m.focusIndex {
+		case 0:
+			m.summary, cmd = m.summary.Update(msg)
+		case 2:
+			m.due, cmd = m.due.Update(msg)
+		}
+		return m, cmd
+	}
+
+	// Non-key messages (cursor blink, etc.)
+	var cmd tea.Cmd
+	switch m.focusIndex {
+	case 0:
+		m.summary, cmd = m.summary.Update(msg)
+	case 1:
+		m.targetInput, cmd = m.targetInput.Update(msg)
+	case 2:
+		m.due, cmd = m.due.Update(msg)
+	}
+	return m, cmd
+}
+
+// View renders the add form.
+func (m Model) View() string {
+	var b strings.Builder
+
+	b.WriteString(titleFormStyle.Render("Add Task"))
+	b.WriteString("\n")
+
+	// Summary
+	b.WriteString(m.renderField("Summary", m.summary.View(), m.focusIndex == 0))
+	b.WriteString("\n")
+
+	// Target
+	targetDisplay := m.renderTargetField()
+	b.WriteString(targetDisplay)
+	b.WriteString("\n")
+
+	// Picker (only when Target is focused)
+	if m.focusIndex == 1 {
+		b.WriteString(m.renderPicker())
+		b.WriteString("\n")
+	}
+
+	// Due
+	b.WriteString(m.renderField("Due", m.due.View(), m.focusIndex == 2))
+	b.WriteString("\n")
+
+	// Priority
+	b.WriteString(m.renderField("Priority", m.renderCycle(priorityOptions, m.priority, m.focusIndex == 3), m.focusIndex == 3))
+	b.WriteString("\n")
+
+	// Status
+	b.WriteString(m.renderField("Status", m.renderCycle(statusOptions, m.status, m.focusIndex == 4), m.focusIndex == 4))
+	b.WriteString("\n")
+
+	// Push (optional)
+	if m.showPush {
+		b.WriteString(m.renderField("Push?", m.renderCycle(pushOptions, m.push, m.focusIndex == 5), m.focusIndex == 5))
+		b.WriteString("\n")
+	}
+
+	hint := "tab/shift+tab: navigate  ←/→: cycle  enter: submit  esc: cancel"
+	if m.showPush {
+		hint += "  y/n: push"
+	}
+	b.WriteString(hintStyle.Render(hint))
+
+	return formStyle.Render(b.String())
+}
+
+func (m Model) renderTargetField() string {
+	label := labelStyle.Render("Target:")
+	var value string
+
+	if m.focusIndex == 1 {
+		// Show filter input and ctrl+x hint
+		if m.ctrlXMode {
+			value = ctrlXHintStyle.Render("^X: d=daily  t=default")
+		} else {
+			value = m.targetInput.View()
+		}
+	} else {
+		// Show confirmed selection
+		sel := "daily"
+		if m.targetSel < len(m.targets) {
+			sel = m.targets[m.targetSel]
+		}
+		value = activeFieldStyle.Render("[ " + sel + " ]")
+		if m.focusIndex != 1 {
+			value = inactiveFieldStyle.Render("[ " + sel + " ]")
+		}
+	}
+
+	return fmt.Sprintf("%s %s", label, value)
+}
+
+func (m Model) renderPicker() string {
+	if len(m.pickerIdx) == 0 {
+		return pickerBoxStyle.Render(inactiveFieldStyle.Render("  no matches"))
+	}
+
+	var rows []string
+	end := m.pickerOff + pickerMaxVisible
+	if end > len(m.pickerIdx) {
+		end = len(m.pickerIdx)
+	}
+
+	for i := m.pickerOff; i < end; i++ {
+		label := m.targets[m.pickerIdx[i]]
+		if i == m.pickerCur {
+			rows = append(rows, pickerActiveStyle.Render("▶ "+label))
+		} else {
+			rows = append(rows, pickerItemStyle.Render("  "+label))
+		}
+	}
+
+	// Scroll indicators
+	content := strings.Join(rows, "\n")
+	if m.pickerOff > 0 {
+		content = inactiveFieldStyle.Render("  ↑ more") + "\n" + content
+	}
+	if end < len(m.pickerIdx) {
+		content = content + "\n" + inactiveFieldStyle.Render("  ↓ more")
+	}
+
+	return pickerBoxStyle.Render(content)
+}
+
+func (m Model) renderField(label, value string, _ bool) string {
+	l := labelStyle.Render(label + ":")
+	return fmt.Sprintf("%s %s", l, value)
+}
+
+func (m Model) renderCycle(options []string, selected int, active bool) string {
+	opt := options[selected]
+	if active {
+		return fmt.Sprintf("<< %s >>", activeFieldStyle.Render("[ "+opt+" ]"))
+	}
+	return inactiveFieldStyle.Render("[ " + opt + " ]")
+}
+
+// Submitted returns true if the user submitted the form.
+func (m Model) Submitted() bool { return m.submitted }
+
+// Cancelled returns true if the user pressed escape.
+func (m Model) Cancelled() bool { return m.cancelled }
+
+// GetSummary returns the task summary.
+func (m Model) GetSummary() string { return m.summary.Value() }
+
+// GetTarget returns the selected target string (e.g. "daily", "default", "projects/work.md").
+func (m Model) GetTarget() string {
+	if m.targetSel < len(m.targets) {
+		return m.targets[m.targetSel]
+	}
+	return "daily"
+}
+
+// GetDue returns the parsed due date, or nil if empty/invalid.
+func (m Model) GetDue() *time.Time {
+	val := strings.TrimSpace(m.due.Value())
+	if val == "" {
+		return nil
+	}
+	t, err := time.Parse("2006-01-02", val)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+// GetPriority returns the selected priority value (0 = none).
+func (m Model) GetPriority() int { return priorityValues[m.priority] }
+
+// GetStatus returns the selected CalDAV status string.
+func (m Model) GetStatus() string { return statusOptions[m.status] }
+
+// GetPush returns true if the user chose to push to CalDAV.
+func (m Model) GetPush() bool { return m.push == 1 }

--- a/internal/vault/writer.go
+++ b/internal/vault/writer.go
@@ -43,12 +43,17 @@ func ToggleTask(t *task.Task) error {
 }
 
 // ResolveTaskFile determines where to add a new task based on the target setting.
-// target: "daily" tries today's daily note, "default" uses the default task file.
+// target: "daily" → today's daily note, "default"/"" → defaultFile, anything else → vault-relative path.
 func ResolveTaskFile(vaultPath, dailyFolder, dailyFormat, defaultFile, target string) string {
 	defaultPath := filepath.Join(vaultPath, defaultFile)
 
-	if target != "daily" {
+	switch target {
+	case "default", "":
 		return defaultPath
+	case "daily":
+		// handled below
+	default:
+		return filepath.Join(vaultPath, target)
 	}
 
 	// Check if the daily notes folder exists

--- a/todo.md
+++ b/todo.md
@@ -39,6 +39,8 @@ Add Cobra for CLI framework, then implement:
 - [x] CalDAV push form: set due date, priority, and status before pushing (interactive overlay)
 - [x] smart task add: route new tasks to today's daily note or default file (`add_task_target` config)
 - [x] CalDAV auto-push: automatically push new tasks on add (`auto_push` config flag)
+- [ ] CalDAV: add `DESCRIPTION` (long-form body, separate from SUMMARY), `DTSTART` (start date), and time support (HH:MM on due/start fields, sends full datetime to VTODO instead of date-only) to add form and VTODO builder
+- [ ] add form: upgrade Description field from single-line input to multi-line textarea
 - [ ] task detail view: press `d` or `enter` to see full task metadata (due, tags, source, CalDAV UID)
 - [ ] open task source in Obsidian: press `o` to launch `obsidian://open?vault=...&file=...` URI — opens the note in the Obsidian app directly from Obia (works from WSL via Windows interop)
 


### PR DESCRIPTION
## Summary

- Replaces the bare single-line add-task input with a full overlay form (`addform` component)
- Form fields: target file (fuzzy picker), due date, priority, status, and an explicit CalDAV push toggle
- `ExtraTargets` config option lets users add custom vault-relative routing destinations alongside `daily` and `default`
- `ResolveTaskFile` now handles arbitrary vault-relative paths as a third routing mode
- `AddTaskWithMetaCmd` replaces `AddTaskWithAutoPushCmd`, forwarding due/priority/status/push to the CalDAV VTODO builder

Also includes the earlier commits on this branch:
- persist CalDAV UID to markdown frontmatter after push (single-task files and inline tasks)

## Test plan

- [ ] `a` opens the add form overlay; `esc` cancels and returns to browser
- [ ] Target picker cycles through `daily`, `default`, and any `extra_targets` from config
- [ ] Due date field accepts `YYYY-MM-DD` and leaves the field blank if empty
- [ ] Priority and status cycle pickers work with `←`/`→`
- [ ] Push toggle only appears when CalDAV URL is configured
- [ ] Submitting with push=Yes sends VTODO to CalDAV with the supplied metadata
- [ ] Submitting with push=No appends the task without any CalDAV call
- [ ] `ResolveTaskFile` routes a vault-relative path (e.g. `projects/work.md`) to the correct absolute path