### PR TITLE
feat: Daily tab + multi-folder config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,7 +42,6 @@ func DefaultConfig() Config {
 	return Config{
 		Vault: Vault{
 			DailyNotesFolder: "diary",
-			Folders:          []string{"diary"},
 			DailyNotesFormat: "2006-01-02",
 			DefaultTaskFile:  "todo.md",
 			AddTaskTarget:    "daily",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,8 @@ import (
 
 type Vault struct {
 	Path             string   `toml:"path"`
-	DailyNotesFolder string   `toml:"daily_notes_folder"`
+	DailyNotesFolder string   `toml:"daily_notes_folder"` // kept for backward compat
+	Folders          []string `toml:"folders"`             // generic folder list; takes precedence over daily_notes_folder
 	DailyNotesFormat string   `toml:"daily_notes_format"`
 	DefaultTaskFile  string   `toml:"default_task_file"`
 	AddTaskTarget    string   `toml:"add_task_target"`   // "daily" | "default" | vault-relative path
@@ -41,6 +42,7 @@ func DefaultConfig() Config {
 	return Config{
 		Vault: Vault{
 			DailyNotesFolder: "diary",
+			Folders:          []string{"diary"},
 			DailyNotesFormat: "2006-01-02",
 			DefaultTaskFile:  "todo.md",
 			AddTaskTarget:    "daily",

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -62,7 +62,7 @@ func NewApp(cfg config.Config) App {
 	vp := cfg.Vault.Path
 	dfmt := cfg.Vault.DailyNotesFormat
 	dfs := cfg.Vault.Folders
-	if len(dfs) == 0 {
+	if len(dfs) == 0 && cfg.Vault.DailyNotesFolder != "" {
 		dfs = []string{cfg.Vault.DailyNotesFolder}
 	}
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -60,14 +60,18 @@ func NewApp(cfg config.Config) App {
 	ctx := appctx.New(cfg)
 
 	vp := cfg.Vault.Path
-	df := cfg.Vault.DailyNotesFolder
 	dfmt := cfg.Vault.DailyNotesFormat
+	dfs := cfg.Vault.Folders
+	if len(dfs) == 0 {
+		dfs = []string{cfg.Vault.DailyNotesFolder}
+	}
 
 	sections := []section.Section{
-		tasksection.New("Tasks", vp, df, dfmt, tasksection.FilterOpen),
-		tasksection.New("Weekly", vp, df, dfmt, tasksection.FilterWeekly),
-		tasksection.New("Overdue", vp, df, dfmt, tasksection.FilterOverdue),
-		tasksection.New("CalDAV", vp, df, dfmt, tasksection.FilterCalDAV),
+		tasksection.New("Tasks",   vp, dfs, dfmt, tasksection.FilterOpen),
+		tasksection.New("Daily",   vp, dfs, dfmt, tasksection.FilterDailyFolders),
+		tasksection.New("Weekly",  vp, dfs, dfmt, tasksection.FilterWeekly),
+		tasksection.New("Overdue", vp, dfs, dfmt, tasksection.FilterOverdue),
+		tasksection.New("CalDAV",  vp, dfs, dfmt, tasksection.FilterCalDAV),
 	}
 
 	if cfg.UI.Grouped {

--- a/internal/tui/components/tasksection/model.go
+++ b/internal/tui/components/tasksection/model.go
@@ -239,14 +239,17 @@ func FilterWeekly(tasks []task.Task, folders []string, dailyFormat string) []tas
 	daysBackToSunday := int(now.Weekday()) // 0=Sun, 1=Mon, …, 6=Sat
 	weekStart := time.Date(now.Year(), now.Month(), now.Day()-daysBackToSunday, 0, 0, 0, 0, now.Location())
 	weekEnd := weekStart.AddDate(0, 0, 7)
+	days := make([]string, 7)
+	for d := 0; d < 7; d++ {
+		days[d] = weekStart.AddDate(0, 0, d).Format(dailyFormat)
+	}
 	var out []task.Task
 outer:
 	for i := range tasks {
 		t := &tasks[i]
 		for _, folder := range folders {
 			for d := 0; d < 7; d++ {
-				day := weekStart.AddDate(0, 0, d)
-				if strings.Contains(t.Source.FilePath, folder+"/"+day.Format(dailyFormat)) {
+				if strings.Contains(t.Source.FilePath, "/"+folder+"/"+days[d]) {
 					if !t.IsDone() {
 						out = append(out, *t)
 					}
@@ -254,7 +257,7 @@ outer:
 				}
 			}
 		}
-		if t.Due != nil && !t.Due.Before(weekStart) && t.Due.Before(weekEnd) {
+		if t.Due != nil && !t.Due.Before(weekStart) && t.Due.Before(weekEnd) && !t.IsDone() {
 			out = append(out, *t)
 		}
 	}

--- a/internal/tui/components/tasksection/model.go
+++ b/internal/tui/components/tasksection/model.go
@@ -99,6 +99,8 @@ func (m *Model) viewFlat(width, height, cursor int, selected bool) string {
 		if t.IsDone() {
 			checkbox = "[x]"
 			style = taskDoneStyle
+		} else if t.CalDAVUID != "" {
+			style = taskCalDAVStyle
 		}
 
 		relPath := t.RelativePath(m.vaultPath)
@@ -147,6 +149,8 @@ func (m *Model) viewGrouped(width, height, cursor int, selected bool) string {
 		if t.IsDone() {
 			checkbox = "[x]"
 			style = taskDoneStyle
+		} else if t.CalDAVUID != "" {
+			style = taskCalDAVStyle
 		}
 
 		row := style.Render(fmt.Sprintf("    %s %s", checkbox, t.Description))
@@ -212,6 +216,7 @@ func (t taskSource) Len() int            { return len(t) }
 var (
 	taskTodoStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
 	taskDoneStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("242")).Strikethrough(true)
+	taskCalDAVStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#00C48C"))
 	selectedStyle   = lipgloss.NewStyle().Background(lipgloss.Color("236")).Bold(true)
 	sourceStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 	fileHeaderStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("170")).Bold(true)

--- a/internal/tui/components/tasksection/model.go
+++ b/internal/tui/components/tasksection/model.go
@@ -13,14 +13,14 @@ import (
 )
 
 // FilterFunc decides which tasks belong in this section.
-type FilterFunc func(tasks []task.Task, dailyFolder, dailyFormat string) []task.Task
+type FilterFunc func(tasks []task.Task, folders []string, dailyFormat string) []task.Task
 
 // Model implements section.Section for a filtered task list view.
 type Model struct {
 	title       string
 	filterFn    FilterFunc
 	vaultPath   string
-	dailyFolder string
+	folders     []string
 	dailyFormat string
 	filtered    []task.Task
 	search      string
@@ -29,12 +29,12 @@ type Model struct {
 
 var _ section.Section = (*Model)(nil)
 
-func New(title, vaultPath, dailyFolder, dailyFormat string, filterFn FilterFunc) *Model {
+func New(title, vaultPath string, folders []string, dailyFormat string, filterFn FilterFunc) *Model {
 	return &Model{
 		title:       title,
 		filterFn:    filterFn,
 		vaultPath:   vaultPath,
-		dailyFolder: dailyFolder,
+		folders:     folders,
 		dailyFormat: dailyFormat,
 	}
 }
@@ -42,7 +42,7 @@ func New(title, vaultPath, dailyFolder, dailyFormat string, filterFn FilterFunc)
 func (m *Model) Title() string { return m.title }
 
 func (m *Model) SetTasks(all []task.Task) {
-	m.filtered = m.filterFn(all, m.dailyFolder, m.dailyFormat)
+	m.filtered = m.filterFn(all, m.folders, m.dailyFormat)
 	m.applySearch()
 }
 
@@ -219,7 +219,7 @@ var (
 
 // --- Built-in filter functions ---
 
-func FilterOpen(tasks []task.Task, _, _ string) []task.Task {
+func FilterOpen(tasks []task.Task, _ []string, _ string) []task.Task {
 	var out []task.Task
 	for i := range tasks {
 		if !tasks[i].IsDone() {
@@ -229,31 +229,50 @@ func FilterOpen(tasks []task.Task, _, _ string) []task.Task {
 	return out
 }
 
-func FilterWeekly(tasks []task.Task, dailyFolder, dailyFormat string) []task.Task {
+func FilterWeekly(tasks []task.Task, folders []string, dailyFormat string) []task.Task {
 	now := time.Now()
 	daysBackToSunday := int(now.Weekday()) // 0=Sun, 1=Mon, …, 6=Sat
 	weekStart := time.Date(now.Year(), now.Month(), now.Day()-daysBackToSunday, 0, 0, 0, 0, now.Location())
 	weekEnd := weekStart.AddDate(0, 0, 7)
 	var out []task.Task
+outer:
 	for i := range tasks {
 		t := &tasks[i]
-		// Include daily notes from any day this week
-		for d := 0; d < 7; d++ {
-			day := weekStart.AddDate(0, 0, d)
-			if strings.Contains(t.Source.FilePath, dailyFolder+"/"+day.Format(dailyFormat)) {
-				out = append(out, *t)
-				goto next
+		for _, folder := range folders {
+			for d := 0; d < 7; d++ {
+				day := weekStart.AddDate(0, 0, d)
+				if strings.Contains(t.Source.FilePath, folder+"/"+day.Format(dailyFormat)) {
+					if !t.IsDone() {
+						out = append(out, *t)
+					}
+					continue outer
+				}
 			}
 		}
 		if t.Due != nil && !t.Due.Before(weekStart) && t.Due.Before(weekEnd) {
 			out = append(out, *t)
 		}
-	next:
 	}
 	return out
 }
 
-func FilterOverdue(tasks []task.Task, _, _ string) []task.Task {
+func FilterDailyFolders(tasks []task.Task, folders []string, _ string) []task.Task {
+	var out []task.Task
+	for i := range tasks {
+		t := &tasks[i]
+		for _, folder := range folders {
+			if strings.Contains(t.Source.FilePath, "/"+folder+"/") {
+				if !t.IsDone() {
+					out = append(out, *t)
+				}
+				break
+			}
+		}
+	}
+	return out
+}
+
+func FilterOverdue(tasks []task.Task, _ []string, _ string) []task.Task {
 	now := time.Now()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	var out []task.Task
@@ -266,7 +285,7 @@ func FilterOverdue(tasks []task.Task, _, _ string) []task.Task {
 	return out
 }
 
-func FilterCalDAV(tasks []task.Task, _, _ string) []task.Task {
+func FilterCalDAV(tasks []task.Task, _ []string, _ string) []task.Task {
 	var out []task.Task
 	for i := range tasks {
 		if tasks[i].CalDAVUID != "" {


### PR DESCRIPTION
## Summary

- Adds a new **Daily** tab that shows all pending tasks from configured vault folders — no date restriction
- Changes `[vault]` config to support `folders = ["diary", "journal"]` (array), replacing the single `daily_notes_folder` for this purpose; old field kept for backward compatibility
- Updates `FilterWeekly` to iterate all configured folders (Sun–Sat window, undone tasks only)
- `FilterFunc` signature updated from `(tasks, dailyFolder string, dailyFormat string)` → `(tasks, folders []string, dailyFormat string)`

## Config

```toml
[vault]
folders = ["diary", "journal"]  # any number of folders
```

Falls back to `daily_notes_folder` if `folders` is not set.

## Test plan

- [ ] `go build` compiles clean
- [ ] Daily tab shows all pending tasks from `diary/` with no date cap
- [ ] Weekly tab still shows only Sun–Sat undone tasks
- [ ] Adding a second folder to `folders` makes tasks from both appear in Daily tab
- [ ] Existing config with only `daily_notes_folder` still works (backward compat)