### PR TITLE
feat: instant startup via task cache

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,14 @@ func ConfigPath() (string, error) {
 	return filepath.Join(dir, "config.toml"), nil
 }
 
+func CachePath() (string, error) {
+	dir, err := configDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "cache.json"), nil
+}
+
 func Load() (Config, error) {
 	cfg := DefaultConfig()
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -47,8 +47,9 @@ type App struct {
 	sections  []section.Section
 	activeTab int
 	cursor    int
-	loading   bool
-	cachePath string
+	loading        bool
+	loadedFromScan bool
+	cachePath      string
 
 	spinner spinner.Model
 
@@ -117,17 +118,19 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.ctx.SetSize(msg.Width, msg.Height)
 
 	case TasksLoadedMsg:
-		// Cache hit — show tasks instantly; loading already false if cache existed
-		if msg.Err == nil {
+		if msg.Err == nil && !a.loadedFromScan {
 			a.allTasks = msg.Tasks
 			a.refreshSections()
 			a.loading = false
+		} else if msg.Err != nil {
+			a.loading = true
 		}
-		// If cache miss, keep loading=true until TasksRefreshedMsg arrives
 
 	case TasksRefreshedMsg:
-		// Background scan complete — silently update tasks
-		if msg.Err == nil {
+		a.loadedFromScan = true
+		if msg.Err != nil {
+			a.message = "Error scanning vault: " + msg.Err.Error()
+		} else {
 			a.allTasks = msg.Tasks
 			a.refreshSections()
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -47,6 +48,7 @@ type App struct {
 	activeTab int
 	cursor    int
 	loading   bool
+	cachePath string
 
 	spinner spinner.Model
 
@@ -82,19 +84,29 @@ func NewApp(cfg config.Config) App {
 	sp.Spinner = spinner.Dot
 	sp.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("#7C3AED"))
 
+	cachePath, _ := config.CachePath()
+	hasCache := false
+	if cachePath != "" {
+		if _, err := os.Stat(cachePath); err == nil {
+			hasCache = true
+		}
+	}
+
 	return App{
-		ctx:      ctx,
-		keys:     keys.DefaultKeyMap,
-		mode:     modeBrowser,
-		sections: sections,
-		loading:  true,
-		spinner:  sp,
+		ctx:       ctx,
+		keys:      keys.DefaultKeyMap,
+		mode:      modeBrowser,
+		sections:  sections,
+		loading:   !hasCache,
+		cachePath: cachePath,
+		spinner:   sp,
 	}
 }
 
 func (a App) Init() tea.Cmd {
 	return tea.Batch(
-		LoadTasksCmd(a.ctx.VaultPath(), a.ctx.Config.Vault.TaskFilesFolder),
+		LoadCacheCmd(a.cachePath),
+		LoadTasksCmd(a.ctx.VaultPath(), a.ctx.Config.Vault.TaskFilesFolder, a.cachePath),
 		a.spinner.Tick,
 	)
 }
@@ -105,9 +117,17 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.ctx.SetSize(msg.Width, msg.Height)
 
 	case TasksLoadedMsg:
-		if msg.Err != nil {
-			a.message = "Error loading tasks: " + msg.Err.Error()
-		} else {
+		// Cache hit — show tasks instantly; loading already false if cache existed
+		if msg.Err == nil {
+			a.allTasks = msg.Tasks
+			a.refreshSections()
+			a.loading = false
+		}
+		// If cache miss, keep loading=true until TasksRefreshedMsg arrives
+
+	case TasksRefreshedMsg:
+		// Background scan complete — silently update tasks
+		if msg.Err == nil {
 			a.allTasks = msg.Tasks
 			a.refreshSections()
 		}
@@ -138,7 +158,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			a.message = "Task added"
 		}
-		return a, LoadTasksCmd(a.ctx.VaultPath(), a.ctx.Config.Vault.TaskFilesFolder)
+		return a, LoadTasksCmd(a.ctx.VaultPath(), a.ctx.Config.Vault.TaskFilesFolder, a.cachePath)
 
 	case PullCalDAVMsg:
 		if msg.Err != nil {
@@ -148,7 +168,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.Notify != "" {
 				a.message += " · " + msg.Notify
 			}
-			return a, LoadTasksCmd(a.ctx.VaultPath(), a.ctx.Config.Vault.TaskFilesFolder)
+			return a, LoadTasksCmd(a.ctx.VaultPath(), a.ctx.Config.Vault.TaskFilesFolder, a.cachePath)
 		}
 
 	case TaskEditedMsg:
@@ -160,7 +180,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				a.message = "Task updated"
 			}
-			return a, LoadTasksCmd(a.ctx.VaultPath(), a.ctx.Config.Vault.TaskFilesFolder)
+			return a, LoadTasksCmd(a.ctx.VaultPath(), a.ctx.Config.Vault.TaskFilesFolder, a.cachePath)
 		} else {
 			msg.Task.Description = msg.NewSummary
 			a.syncBack(msg.Task)
@@ -323,7 +343,7 @@ func (a App) handleBrowserKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, a.keys.Reload):
 		a.loading = true
-		return a, LoadTasksCmd(a.ctx.VaultPath(), a.ctx.Config.Vault.TaskFilesFolder)
+		return a, LoadTasksCmd(a.ctx.VaultPath(), a.ctx.Config.Vault.TaskFilesFolder, a.cachePath)
 	}
 
 	return a, nil

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -15,11 +15,22 @@ import (
 	"github.com/hawkaii/obia/internal/vault"
 )
 
-// LoadTasksCmd scans the vault and returns all parsed tasks.
-func LoadTasksCmd(vaultPath, taskFilesFolder string) tea.Cmd {
+// LoadCacheCmd reads the task cache from disk and returns it instantly.
+func LoadCacheCmd(cachePath string) tea.Cmd {
+	return func() tea.Msg {
+		tasks, err := vault.LoadCache(cachePath)
+		return TasksLoadedMsg{Tasks: tasks, Err: err}
+	}
+}
+
+// LoadTasksCmd scans the vault, saves the result to cache, and returns a refresh message.
+func LoadTasksCmd(vaultPath, taskFilesFolder, cachePath string) tea.Cmd {
 	return func() tea.Msg {
 		tasks, err := vault.ParseAllTasks(vaultPath, taskFilesFolder)
-		return TasksLoadedMsg{Tasks: tasks, Err: err}
+		if err == nil && cachePath != "" {
+			_ = vault.SaveCache(tasks, cachePath)
+		}
+		return TasksRefreshedMsg{Tasks: tasks, Err: err}
 	}
 }
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -2,8 +2,14 @@ package tui
 
 import "github.com/hawkaii/obia/internal/task"
 
-// TasksLoadedMsg is sent when vault parsing completes.
+// TasksLoadedMsg is sent when the task cache is loaded instantly on startup.
 type TasksLoadedMsg struct {
+	Tasks []task.Task
+	Err   error
+}
+
+// TasksRefreshedMsg is sent when the background vault scan completes.
+type TasksRefreshedMsg struct {
 	Tasks []task.Task
 	Err   error
 }

--- a/internal/vault/cache.go
+++ b/internal/vault/cache.go
@@ -1,0 +1,25 @@
+package vault
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/hawkaii/obia/internal/task"
+)
+
+func SaveCache(tasks []task.Task, path string) error {
+	data, err := json.Marshal(tasks)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func LoadCache(path string) ([]task.Task, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var tasks []task.Task
+	return tasks, json.Unmarshal(data, &tasks)
+}

--- a/internal/vault/cache.go
+++ b/internal/vault/cache.go
@@ -3,11 +3,15 @@ package vault
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 
 	"github.com/hawkaii/obia/internal/task"
 )
 
 func SaveCache(tasks []task.Task, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
 	data, err := json.Marshal(tasks)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- First run: vault is scanned normally, spinner shows briefly, result saved to `~/.config/obia/cache.json`
- Second+ runs: cache loaded instantly (no spinner), background scan runs in parallel and silently updates tasks when done

## How it works

| Startup | Behavior |
|---------|----------|
| No cache | `loading=true`, spinner shows until background scan finishes |
| Cache exists | `loading=false`, tasks shown immediately from cache, background scan silently refreshes |

## New files / changes

- `internal/vault/cache.go` — `SaveCache` / `LoadCache` (JSON)
- `internal/config/config.go` — `CachePath()` → `~/.config/obia/cache.json`
- `internal/tui/messages.go` — new `TasksRefreshedMsg` (background scan result)
- `internal/tui/commands.go` — `LoadCacheCmd` (instant) + `LoadTasksCmd` now saves cache and returns `TasksRefreshedMsg`
- `internal/tui/app.go` — `Init()` fires both commands in parallel; `Update()` handles both message types

## Test plan

- [ ] `go build` compiles clean
- [ ] First launch: spinner appears briefly, then tasks load
- [ ] `cache.json` created at `~/.config/obia/`
- [ ] Second launch: tasks appear immediately with no spinner
- [ ] After adding/toggling a task, cache is updated for next launch