### PR TITLE
feat: ctrl+g opens selected task in $EDITOR

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -210,6 +210,16 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.message = "Pushed to CalDAV: " + msg.Task.Description
 		}
 
+	case EditorClosedMsg:
+		if msg.Err != nil {
+			a.message = "Editor error: " + msg.Err.Error()
+		}
+		a.loading = true
+		return a, tea.Batch(
+			LoadTasksCmd(a.ctx.VaultPath(), a.ctx.Config.Vault.TaskFilesFolder, a.cachePath),
+			a.spinner.Tick,
+		)
+
 	case spinner.TickMsg:
 		if a.loading {
 			var cmd tea.Cmd
@@ -347,6 +357,13 @@ func (a App) handleBrowserKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		a.editFormTask = t
 		a.mode = modeEditForm
 		return a, nil
+
+	case key.Matches(msg, a.keys.OpenInEditor):
+		tasks := a.activeSection().Tasks()
+		if a.cursor < len(tasks) {
+			t := &tasks[a.cursor]
+			return a, OpenInEditorCmd(t.Source.FilePath, t.Source.Line)
+		}
 
 	case key.Matches(msg, a.keys.Reload):
 		a.loading = true

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -21,6 +22,27 @@ func LoadCacheCmd(cachePath string) tea.Cmd {
 		tasks, err := vault.LoadCache(cachePath)
 		return TasksLoadedMsg{Tasks: tasks, Err: err}
 	}
+}
+
+// OpenInEditorCmd suspends the TUI and opens filePath in $EDITOR at the given line.
+// vim/nvim/vi get a +N flag to jump directly to the line.
+func OpenInEditorCmd(filePath string, line int) tea.Cmd {
+	editorEnv := os.Getenv("EDITOR")
+	if editorEnv == "" {
+		editorEnv = "vim"
+	}
+	parts := strings.Fields(editorEnv)
+	editor := parts[0]
+	editorArgs := parts[1:]
+	args := []string{filePath}
+	base := filepath.Base(editor)
+	if base == "vim" || base == "nvim" || base == "vi" {
+		args = []string{fmt.Sprintf("+%d", line), filePath}
+	}
+	c := exec.Command(editor, append(editorArgs, args...)...)
+	return tea.ExecProcess(c, func(err error) tea.Msg {
+		return EditorClosedMsg{Err: err}
+	})
 }
 
 // LoadTasksCmd scans the vault, saves the result to cache, and returns a refresh message.

--- a/internal/tui/keys/keys.go
+++ b/internal/tui/keys/keys.go
@@ -15,9 +15,10 @@ type KeyMap struct {
 	AddTask    key.Binding
 	Reload     key.Binding
 	Pull       key.Binding
-	EditTask   key.Binding
-	ToggleView key.Binding
-	Quit       key.Binding
+	EditTask     key.Binding
+	OpenInEditor key.Binding
+	ToggleView   key.Binding
+	Quit         key.Binding
 	Escape     key.Binding
 	Backspace  key.Binding
 	Enter      key.Binding
@@ -76,6 +77,10 @@ var DefaultKeyMap = KeyMap{
 		key.WithKeys("e"),
 		key.WithHelp("e", "edit"),
 	),
+	OpenInEditor: key.NewBinding(
+		key.WithKeys("ctrl+g"),
+		key.WithHelp("ctrl+g", "open in editor"),
+	),
 	ToggleView: key.NewBinding(
 		key.WithKeys("v"),
 		key.WithHelp("v", "view"),
@@ -98,5 +103,5 @@ var DefaultKeyMap = KeyMap{
 
 // BrowserHelp returns the help text for the browser mode status bar.
 func BrowserHelp() string {
-	return "  ↑/k ↓/j navigate  enter: toggle  a: add  e: edit  p: push  R: pull  /: filter  v: view  tab: switch  r: reload  q: quit"
+	return "  ↑/k ↓/j navigate  enter: toggle  a: add  e: edit  ctrl+g: open  p: push  R: pull  /: filter  v: view  tab: switch  r: reload  q: quit"
 }

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -53,6 +53,9 @@ type TaskEditedMsg struct {
 	CalDAVErr  error // non-nil if save succeeded but CalDAV push failed
 }
 
+// EditorClosedMsg is sent when the external editor process exits.
+type EditorClosedMsg struct{ Err error }
+
 // ErrorMsg represents a generic error.
 type ErrorMsg struct {
 	Err error


### PR DESCRIPTION
## Summary

- Press **Ctrl+G** on any selected task to open its source `.md` file in your terminal editor
- TUI suspends cleanly, editor takes over the terminal
- For `vim` / `nvim` / `vi`: jumps directly to the task's line with `+N`
- Falls back to `vim` if `$EDITOR` is not set
- On editor exit: TUI resumes and reloads tasks to pick up any changes made

## Test plan

- [ ] `go build` compiles clean
- [ ] Select a task, press Ctrl+G → editor opens at correct file and line
- [ ] Edit the task in the editor, save, exit → TUI shows updated task
- [ ] Works with `$EDITOR=nvim`, `$EDITOR=nano`, and unset `$EDITOR`