### PR TITLE
feat: make tabs config-driven with composable filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Obia scans every `.md` file in your [Obsidian](https://obsidian.md) vault, pulls
 ## Features
 
 - **All your tasks, one place** — Parses `- [ ]` / `- [x]` from every markdown file in your vault
-- **Tabbed views** — Tasks, Daily, Weekly (Sun–Sat), Overdue, CalDAV — switch with <kbd>Tab</kbd>
+- **Tabbed views** — Fully configurable tabs (defaults: Tasks, Overdue, CalDAV) — switch with <kbd>Tab</kbd>
 - **Vim-style navigation** — <kbd>j</kbd>/<kbd>k</kbd> to move, <kbd>g</kbd>/<kbd>G</kbd> for top/bottom
 - **Toggle done** — Hit <kbd>Enter</kbd> to check/uncheck, writes back to the `.md` file instantly
 - **Open in editor** — Press <kbd>Ctrl+G</kbd> to open the task's source file in `$EDITOR` at the exact line
@@ -87,6 +87,31 @@ url = ""
 username = ""
 password = ""
 auto_push = false               # push new tasks to CalDAV automatically on add
+
+# Tab configuration (optional — defaults to Tasks, Overdue, CalDAV if omitted)
+[[ui.tabs]]
+name = "Tasks"
+filter = "open"
+
+[[ui.tabs]]
+name = "Overdue"
+filter = "overdue"
+
+[[ui.tabs]]
+name = "CalDAV"
+filter = "caldav"
+
+[[ui.tabs]]
+name = "Daily"
+filter = "folder"
+folders = ["diary"]
+
+[[ui.tabs]]
+name = "Weekly"
+filter = "timewindow"
+window = "week"
+folders = ["diary"]
+# week_start = "monday"   # optional; default is "sunday"
 ```
 
 ### 2. Run it
@@ -155,20 +180,90 @@ Tasks appear in the default **Reminders** list on iOS. They will **not** appear 
 
 ## Tabs
 
-- **Tasks** — All open tasks across your vault
-- **Daily** — All pending tasks from your configured daily-note folders (no date limit)
-- **Weekly** — Pending tasks from the current calendar week (Sun–Sat), including tasks due this week
-- **Overdue** — Tasks past their due date
-- **CalDAV** — Tasks synced with your CalDAV server
+Tabs are fully configurable in your `config.toml` under `[[ui.tabs]]`. When no tabs are configured, three defaults are injected: **Tasks**, **Overdue**, **CalDAV**.
 
-The Daily and Weekly tabs use the `folders` config key. Set it to scan multiple folders:
+### Filter types
+
+| Filter | Description |
+|--------|------------|
+| `open` | All open tasks |
+| `overdue` | Tasks past their due date |
+| `caldav` | Tasks synced with CalDAV server |
+| `folder` | Tasks from specific folders (`folders` required) |
+| `timewindow` | Calendar-aligned window: `week` or `month` |
+| `rolling` | N days forward from today (`days` required) |
+| `file` | Tasks from a specific file (`file` required) |
+| `tag` | Tasks with a specific tag (`tag` required) |
+| `wikilink` | Tasks linking to a specific page (`wikilink` required) |
+
+### Config example
 
 ```toml
-[vault]
-folders = ["diary", "journal"]   # shown in Daily + Weekly tabs
+[[ui.tabs]]
+name = "Tasks"
+filter = "open"
+
+[[ui.tabs]]
+name = "Overdue"
+filter = "overdue"
+
+[[ui.tabs]]
+name = "CalDAV"
+filter = "caldav"
+show_done = true    # include completed CalDAV tasks
+
+[[ui.tabs]]
+name = "Diary"
+filter = "folder"
+folders = ["diary"]
+
+[[ui.tabs]]
+name = "Weekly"
+filter = "timewindow"
+window = "week"
+folders = ["diary"]
+
+[[ui.tabs]]
+name = "This Month"
+filter = "timewindow"
+window = "month"
+folders = ["diary"]
+
+[[ui.tabs]]
+name = "Next 14 Days"
+filter = "rolling"
+days = 14
+folders = ["diary"]
+
+[[ui.tabs]]
+name = "DSA"
+filter = "file"
+file = "dsa.md"
+
+[[ui.tabs]]
+name = "Urgent"
+filter = "tag"
+tag = "urgent"
 ```
 
-If `folders` is not set, it falls back to `daily_notes_folder`.
+### Time window options
+
+For `filter = "timewindow"`:
+
+- `window = "week"` — current calendar week (aligned to `week_start`): `sunday` (default) or `monday`
+- `window = "month"` — current calendar month
+
+### Rolling options
+
+For `filter = "rolling"`:
+
+- `days = 14` — N days forward from today
+
+Both `timewindow` and `rolling` match against task **due dates** AND **folder filenames** (e.g., `diary/2026-04-25.md`). If `folders` is not set, filename-date matching is disabled and a warning appears in the tab.
+
+### Show done tasks
+
+By default, done tasks are hidden. Set `show_done = true` on any tab to include completed tasks.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 type Vault struct {
 	Path             string   `toml:"path"`
 	DailyNotesFolder string   `toml:"daily_notes_folder"` // kept for backward compat
-	Folders          []string `toml:"folders"`             // generic folder list; takes precedence over daily_notes_folder
+	Folders          []string `toml:"folders"`            // generic folder list; takes precedence over daily_notes_folder
 	DailyNotesFormat string   `toml:"daily_notes_format"`
 	DefaultTaskFile  string   `toml:"default_task_file"`
 	AddTaskTarget    string   `toml:"add_task_target"`   // "daily" | "default" | vault-relative path
@@ -27,9 +27,23 @@ type CalDAV struct {
 	AutoPush bool   `toml:"auto_push"`
 }
 
+type TabConfig struct {
+	Name      string   `toml:"name"`
+	Filter    string   `toml:"filter"`     // open|folder|file|timewindow|rolling|overdue|caldav|tag|wikilink
+	File      string   `toml:"file"`       // filter="file": vault-relative path
+	Folders   []string `toml:"folders"`    // folder-based filters: vault-relative folder names
+	Window    string   `toml:"window"`     // filter="timewindow": "week" | "month"
+	WeekStart string   `toml:"week_start"` // filter="timewindow" window="week": "sunday"(default)|"monday"
+	Days      int      `toml:"days"`       // filter="rolling": number of days forward from today
+	Tag       string   `toml:"tag"`        // filter="tag": hashtag to match (# prefix optional)
+	WikiLink  string   `toml:"wikilink"`   // filter="wikilink": exact inner text of [[...]]
+	ShowDone  bool     `toml:"show_done"`  // if true, include completed tasks (default false)
+}
+
 type UI struct {
-	DefaultTab string `toml:"default_tab"`
-	Grouped    bool   `toml:"grouped"`
+	DefaultTab string      `toml:"default_tab"`
+	Grouped    bool        `toml:"grouped"`
+	Tabs       []TabConfig `toml:"tabs"`
 }
 
 type Config struct {
@@ -50,6 +64,7 @@ func DefaultConfig() Config {
 		},
 		UI: UI{
 			DefaultTab: "tasks",
+			// Tabs intentionally empty - Load() injects defaults when absent.
 		},
 	}
 }
@@ -89,6 +104,13 @@ func Load() (Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			if len(cfg.UI.Tabs) == 0 {
+				cfg.UI.Tabs = []TabConfig{
+					{Name: "Tasks", Filter: "open"},
+					{Name: "Overdue", Filter: "overdue"},
+					{Name: "CalDAV", Filter: "caldav"},
+				}
+			}
 			return cfg, nil
 		}
 		return cfg, fmt.Errorf("reading config: %w", err)
@@ -96,6 +118,14 @@ func Load() (Config, error) {
 
 	if err := toml.Unmarshal(data, &cfg); err != nil {
 		return cfg, fmt.Errorf("parsing config: %w", err)
+	}
+
+	if len(cfg.UI.Tabs) == 0 {
+		cfg.UI.Tabs = []TabConfig{
+			{Name: "Tasks", Filter: "open"},
+			{Name: "Overdue", Filter: "overdue"},
+			{Name: "CalDAV", Filter: "caldav"},
+		}
 	}
 
 	return cfg, nil

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -43,10 +43,10 @@ type App struct {
 	input     string
 	message   string
 
-	allTasks  []task.Task
-	sections  []section.Section
-	activeTab int
-	cursor    int
+	allTasks       []task.Task
+	sections       []section.Section
+	activeTab      int
+	cursor         int
 	loading        bool
 	loadedFromScan bool
 	cachePath      string
@@ -68,13 +68,66 @@ func NewApp(cfg config.Config) App {
 	if len(dfs) == 0 && cfg.Vault.DailyNotesFolder != "" {
 		dfs = []string{cfg.Vault.DailyNotesFolder}
 	}
+	_ = dfs
 
-	sections := []section.Section{
-		tasksection.New("Tasks",   vp, dfs, dfmt, tasksection.FilterOpen),
-		tasksection.New("Daily",   vp, dfs, dfmt, tasksection.FilterDailyFolders),
-		tasksection.New("Weekly",  vp, dfs, dfmt, tasksection.FilterWeekly),
-		tasksection.New("Overdue", vp, dfs, dfmt, tasksection.FilterOverdue),
-		tasksection.New("CalDAV",  vp, dfs, dfmt, tasksection.FilterCalDAV),
+	var sections []section.Section
+	for _, tab := range cfg.UI.Tabs {
+		tabFolders := tab.Folders
+
+		var fn tasksection.FilterFunc
+		var warningParts []string
+
+		switch tab.Filter {
+		case "open":
+			fn = tasksection.FilterOpen
+		case "folder":
+			fn = tasksection.MakeFolderFilter(vp, tabFolders)
+		case "timewindow":
+			if len(tabFolders) == 0 {
+				warningParts = append(warningParts, "no folders set - filename-date matching disabled")
+			}
+			fn = tasksection.MakeTimeWindowFilter(vp, tabFolders, dfmt, tab.Window, tab.WeekStart)
+		case "rolling":
+			if tab.Days == 0 {
+				warningParts = append(warningParts, "days must be > 0")
+			}
+			if len(tabFolders) == 0 {
+				warningParts = append(warningParts, "no folders set - filename-date matching disabled")
+			}
+			fn = tasksection.MakeRollingFilter(vp, tabFolders, dfmt, tab.Days)
+		case "overdue":
+			fn = tasksection.FilterOverdue
+		case "caldav":
+			fn = tasksection.FilterCalDAV
+		case "file":
+			fn = tasksection.MakeFileFilter(vp, tab.File)
+		case "tag":
+			fn = tasksection.MakeTagFilter(tab.Tag)
+		case "wikilink":
+			fn = tasksection.MakeWikiLinkFilter(tab.WikiLink)
+		default:
+			fn = tasksection.FilterOpen
+		}
+
+		if !tab.ShowDone {
+			inner := fn
+			fn = func(tasks []task.Task) []task.Task {
+				all := inner(tasks)
+				out := make([]task.Task, 0, len(all))
+				for _, t := range all {
+					if !t.IsDone() {
+						out = append(out, t)
+					}
+				}
+				return out
+			}
+		}
+
+		s := tasksection.New(tab.Name, vp, fn)
+		if len(warningParts) > 0 {
+			s.SetWarning(strings.Join(warningParts, "; "))
+		}
+		sections = append(sections, s)
 	}
 
 	if cfg.UI.Grouped {

--- a/internal/tui/components/tasksection/model.go
+++ b/internal/tui/components/tasksection/model.go
@@ -2,6 +2,7 @@ package tasksection
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -13,36 +14,35 @@ import (
 )
 
 // FilterFunc decides which tasks belong in this section.
-type FilterFunc func(tasks []task.Task, folders []string, dailyFormat string) []task.Task
+type FilterFunc func(tasks []task.Task) []task.Task
 
 // Model implements section.Section for a filtered task list view.
 type Model struct {
-	title       string
-	filterFn    FilterFunc
-	vaultPath   string
-	folders     []string
-	dailyFormat string
-	filtered    []task.Task
-	search      string
-	grouped     bool
+	title     string
+	filterFn  FilterFunc
+	vaultPath string
+	warning   string
+	filtered  []task.Task
+	search    string
+	grouped   bool
 }
 
 var _ section.Section = (*Model)(nil)
 
-func New(title, vaultPath string, folders []string, dailyFormat string, filterFn FilterFunc) *Model {
+func New(title, vaultPath string, filterFn FilterFunc) *Model {
 	return &Model{
-		title:       title,
-		filterFn:    filterFn,
-		vaultPath:   vaultPath,
-		folders:     folders,
-		dailyFormat: dailyFormat,
+		title:     title,
+		filterFn:  filterFn,
+		vaultPath: vaultPath,
 	}
 }
+
+func (m *Model) SetWarning(w string) { m.warning = w }
 
 func (m *Model) Title() string { return m.title }
 
 func (m *Model) SetTasks(all []task.Task) {
-	m.filtered = m.filterFn(all, m.folders, m.dailyFormat)
+	m.filtered = m.filterFn(all)
 	m.applySearch()
 }
 
@@ -70,14 +70,20 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 }
 
 func (m *Model) View(width, height, cursor int, selected bool) string {
+	var content string
 	if len(m.filtered) == 0 {
-		return "  No tasks\n"
+		content = "  No tasks\n"
+	} else if m.grouped {
+		content = m.viewGrouped(width, height, cursor, selected)
+	} else {
+		content = m.viewFlat(width, height, cursor, selected)
 	}
 
-	if m.grouped {
-		return m.viewGrouped(width, height, cursor, selected)
+	if m.warning != "" {
+		return warningStyle.Render("  ⚠ "+m.warning) + "\n" + content
 	}
-	return m.viewFlat(width, height, cursor, selected)
+
+	return content
 }
 
 func (m *Model) viewFlat(width, height, cursor int, selected bool) string {
@@ -220,80 +226,28 @@ var (
 	selectedStyle   = lipgloss.NewStyle().Background(lipgloss.Color("236")).Bold(true)
 	sourceStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 	fileHeaderStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("170")).Bold(true)
+	warningStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 )
 
 // --- Built-in filter functions ---
 
-func FilterOpen(tasks []task.Task, _ []string, _ string) []task.Task {
+func FilterOpen(tasks []task.Task) []task.Task {
+	return tasks
+}
+
+func FilterOverdue(tasks []task.Task) []task.Task {
+	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	var out []task.Task
 	for i := range tasks {
-		if !tasks[i].IsDone() {
+		if tasks[i].Due != nil && tasks[i].Due.Before(today) {
 			out = append(out, tasks[i])
 		}
 	}
 	return out
 }
 
-func FilterWeekly(tasks []task.Task, folders []string, dailyFormat string) []task.Task {
-	now := time.Now()
-	daysBackToSunday := int(now.Weekday()) // 0=Sun, 1=Mon, …, 6=Sat
-	weekStart := time.Date(now.Year(), now.Month(), now.Day()-daysBackToSunday, 0, 0, 0, 0, now.Location())
-	weekEnd := weekStart.AddDate(0, 0, 7)
-	days := make([]string, 7)
-	for d := 0; d < 7; d++ {
-		days[d] = weekStart.AddDate(0, 0, d).Format(dailyFormat)
-	}
-	var out []task.Task
-outer:
-	for i := range tasks {
-		t := &tasks[i]
-		for _, folder := range folders {
-			for d := 0; d < 7; d++ {
-				if strings.Contains(t.Source.FilePath, "/"+folder+"/"+days[d]) {
-					if !t.IsDone() {
-						out = append(out, *t)
-					}
-					continue outer
-				}
-			}
-		}
-		if t.Due != nil && !t.Due.Before(weekStart) && t.Due.Before(weekEnd) && !t.IsDone() {
-			out = append(out, *t)
-		}
-	}
-	return out
-}
-
-func FilterDailyFolders(tasks []task.Task, folders []string, _ string) []task.Task {
-	var out []task.Task
-	for i := range tasks {
-		t := &tasks[i]
-		for _, folder := range folders {
-			if strings.Contains(t.Source.FilePath, "/"+folder+"/") {
-				if !t.IsDone() {
-					out = append(out, *t)
-				}
-				break
-			}
-		}
-	}
-	return out
-}
-
-func FilterOverdue(tasks []task.Task, _ []string, _ string) []task.Task {
-	now := time.Now()
-	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	var out []task.Task
-	for i := range tasks {
-		t := &tasks[i]
-		if t.Due != nil && t.Due.Before(today) && !t.IsDone() {
-			out = append(out, *t)
-		}
-	}
-	return out
-}
-
-func FilterCalDAV(tasks []task.Task, _ []string, _ string) []task.Task {
+func FilterCalDAV(tasks []task.Task) []task.Task {
 	var out []task.Task
 	for i := range tasks {
 		if tasks[i].CalDAVUID != "" {
@@ -303,8 +257,134 @@ func FilterCalDAV(tasks []task.Task, _ []string, _ string) []task.Task {
 	return out
 }
 
-func sameDay(a, b time.Time) bool {
-	ay, am, ad := a.Date()
-	by, bm, bd := b.Date()
-	return ay == by && am == bm && ad == bd
+func MakeFolderFilter(vaultPath string, folders []string) FilterFunc {
+	return func(tasks []task.Task) []task.Task {
+		var out []task.Task
+		for i := range tasks {
+			for _, folder := range folders {
+				prefix := vaultPath + "/" + folder + "/"
+				if strings.HasPrefix(tasks[i].Source.FilePath, prefix) {
+					out = append(out, tasks[i])
+					break
+				}
+			}
+		}
+		return out
+	}
+}
+
+func MakeTimeWindowFilter(vaultPath string, folders []string, dailyFormat, window, weekStart string) FilterFunc {
+	startDay := time.Sunday
+	if strings.ToLower(weekStart) == "monday" {
+		startDay = time.Monday
+	}
+
+	return func(tasks []task.Task) []task.Task {
+		now := time.Now()
+		var begin, end time.Time
+
+		switch window {
+		case "week":
+			offset := int(now.Weekday()) - int(startDay)
+			if offset < 0 {
+				offset += 7
+			}
+			begin = time.Date(now.Year(), now.Month(), now.Day()-offset, 0, 0, 0, 0, now.Location())
+			end = begin.AddDate(0, 0, 7)
+		case "month":
+			begin = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+			end = begin.AddDate(0, 1, 0)
+		default:
+			return nil
+		}
+
+		return matchWindow(tasks, vaultPath, folders, dailyFormat, begin, end)
+	}
+}
+
+func MakeRollingFilter(vaultPath string, folders []string, dailyFormat string, days int) FilterFunc {
+	return func(tasks []task.Task) []task.Task {
+		now := time.Now()
+		begin := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		end := begin.AddDate(0, 0, days)
+		return matchWindow(tasks, vaultPath, folders, dailyFormat, begin, end)
+	}
+}
+
+func matchWindow(tasks []task.Task, vaultPath string, folders []string, dailyFormat string, begin, end time.Time) []task.Task {
+	var out []task.Task
+
+outer:
+	for i := range tasks {
+		t := &tasks[i]
+
+		if t.Due != nil && !t.Due.Before(begin) && t.Due.Before(end) {
+			out = append(out, *t)
+			continue
+		}
+
+		for _, folder := range folders {
+			prefix := vaultPath + "/" + folder + "/"
+			if !strings.HasPrefix(t.Source.FilePath, prefix) {
+				continue
+			}
+
+			base := strings.TrimSuffix(filepath.Base(t.Source.FilePath), ".md")
+			d, err := time.Parse(dailyFormat, base)
+			if err != nil {
+				continue
+			}
+
+			if !d.Before(begin) && d.Before(end) {
+				out = append(out, *t)
+				continue outer
+			}
+		}
+	}
+
+	return out
+}
+
+func MakeFileFilter(vaultPath, relFile string) FilterFunc {
+	abs := filepath.Join(vaultPath, relFile)
+	return func(tasks []task.Task) []task.Task {
+		var out []task.Task
+		for i := range tasks {
+			if tasks[i].Source.FilePath == abs {
+				out = append(out, tasks[i])
+			}
+		}
+		return out
+	}
+}
+
+func MakeTagFilter(tag string) FilterFunc {
+	tag = strings.TrimPrefix(tag, "#")
+	return func(tasks []task.Task) []task.Task {
+		var out []task.Task
+		for i := range tasks {
+			for _, tg := range tasks[i].Tags {
+				if tg == tag {
+					out = append(out, tasks[i])
+					break
+				}
+			}
+		}
+		return out
+	}
+}
+
+func MakeWikiLinkFilter(link string) FilterFunc {
+	return func(tasks []task.Task) []task.Task {
+		var out []task.Task
+		for i := range tasks {
+			for _, wl := range tasks[i].WikiLinks {
+				if wl == link {
+					out = append(out, tasks[i])
+					break
+				}
+			}
+		}
+		return out
+	}
 }


### PR DESCRIPTION
## Summary

- Add `[[ui.tabs]]` config for fully customizable browser tabs (no Go changes needed)
- Add composable filter factories: `timewindow`, `rolling`, `folder`, `file`, `tag`, `wikilink`
- Apply universal `show_done` behavior per-tab; skip done-task filtering when `show_done = true`
- Show inline tab warnings for misconfiguration (e.g., rolling with `days = 0` or missing folders)
- Default tabs (`Tasks`, `Overdue`, `CalDAV`) injected when `[[ui.tabs]]` is absent
- Remove hardcoded tab list in `NewApp()` — replaces with config-driven builder loop
- Simplify `FilterFunc` signature to `func([]task.Task) []task.Task`
- Updated README with full `[[ui.tabs]]` docs and example config block