### PR TITLE
feat: add DTSTART and repeat support in add/edit forms and CalDAV sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Tasks appear in the default **Reminders** list on iOS. They will **not** appear 
 | <kbd>Enter</kbd> | Toggle task done/undone |
 | <kbd>Ctrl+G</kbd> | Open task's source file in `$EDITOR` at the exact line |
 | <kbd>a</kbd> | Add new task (opens rich form) |
-| <kbd>e</kbd> | Edit task (summary, due date/time, description, priority, status) |
+| <kbd>e</kbd> | Edit task (summary, start date/time, due date/time, repeat, description, priority, status) |
 | <kbd>p</kbd> | Upgrade plain task to linked task (opens form pre-filled) |
 | <kbd>R</kbd> | Pull all tasks from CalDAV server |
 | <kbd>/</kbd> | Fuzzy search / filter |
@@ -292,7 +292,9 @@ The task file at `tasks/<uid>.md` stores all the metadata:
 ---
 type: task
 caldav-uid: 3f8a1b2c-...
+dtstart: 2026-04-01T09:00:00Z
 due: 2026-04-02T09:00:00Z
+rrule: FREQ=WEEKLY
 priority: 5
 status: NEEDS-ACTION
 ---
@@ -320,7 +322,7 @@ password = "secret"
 ```
 
 ### Push
-Press <kbd>p</kbd> on a plain task to open the form — set due date, time, description, priority, and status, then push. The task line is rewritten to `[[uid|title]]` and a task file is created.
+Press <kbd>p</kbd> on a plain task to open the form — set start date/time, due date/time, repeat, description, priority, and status, then push. The task line is rewritten to `[[uid|title]]` and a task file is created.
 
 When adding a new task with <kbd>a</kbd>, toggle the **Push?** field in the form to push immediately.
 
@@ -401,10 +403,12 @@ Point `vault.path` in your config at any markdown directory and Obia will scan i
 
 ## Roadmap
 
+- [x] Daily tab — all tasks from `diary/*.md` across all dates
+- [x] Config-driven tabs with `[[ui.tabs]]` — fully customizable browser tabs
+- [ ] Stats overview panel — right-side stats sidebar (OpenCode-style) with task counts, due breakdown, CalDAV sync status, top tags/files; press `s` to toggle; auto-hide on narrow terminals
 - [ ] Task detail view — press `d` to render `tasks/<uid>.md` as a preview overlay
 - [ ] Open in Obsidian — press `o` to launch `obsidian://open?vault=...&file=...`
 - [ ] CLI flags (Cobra) — `--vault`, `--config`, `--debug`, `--no-tui`
-- [ ] Daily tab — all tasks from `diary/*.md` across all dates
 - [ ] First-run setup wizard
 - [ ] mtime-based task caching (skip unchanged files)
 - [ ] Multi-line description textarea

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Obia scans every `.md` file in your [Obsidian](https://obsidian.md) vault, pulls
 ## Features
 
 - **All your tasks, one place** — Parses `- [ ]` / `- [x]` from every markdown file in your vault
-- **Tabbed views** — Tasks, Daily, Weekly (Sun–Sat), Overdue, CalDAV — switch with <kbd>Tab</kbd>
+- **Tabbed views** — Fully configurable tabs (defaults: Tasks, Overdue, CalDAV) — switch with <kbd>Tab</kbd>
 - **Vim-style navigation** — <kbd>j</kbd>/<kbd>k</kbd> to move, <kbd>g</kbd>/<kbd>G</kbd> for top/bottom
 - **Toggle done** — Hit <kbd>Enter</kbd> to check/uncheck, writes back to the `.md` file instantly
 - **Open in editor** — Press <kbd>Ctrl+G</kbd> to open the task's source file in `$EDITOR` at the exact line
@@ -87,6 +87,31 @@ url = ""
 username = ""
 password = ""
 auto_push = false               # push new tasks to CalDAV automatically on add
+
+# Tab configuration (optional — defaults to Tasks, Overdue, CalDAV if omitted)
+[[ui.tabs]]
+name = "Tasks"
+filter = "open"
+
+[[ui.tabs]]
+name = "Overdue"
+filter = "overdue"
+
+[[ui.tabs]]
+name = "CalDAV"
+filter = "caldav"
+
+[[ui.tabs]]
+name = "Daily"
+filter = "folder"
+folders = ["diary"]
+
+[[ui.tabs]]
+name = "Weekly"
+filter = "timewindow"
+window = "week"
+folders = ["diary"]
+# week_start = "monday"   # optional; default is "sunday"
 ```
 
 ### 2. Run it
@@ -155,20 +180,90 @@ Tasks appear in the default **Reminders** list on iOS. They will **not** appear 
 
 ## Tabs
 
-- **Tasks** — All open tasks across your vault
-- **Daily** — All pending tasks from your configured daily-note folders (no date limit)
-- **Weekly** — Pending tasks from the current calendar week (Sun–Sat), including tasks due this week
-- **Overdue** — Tasks past their due date
-- **CalDAV** — Tasks synced with your CalDAV server
+Tabs are fully configurable in your `config.toml` under `[[ui.tabs]]`. When no tabs are configured, three defaults are injected: **Tasks**, **Overdue**, **CalDAV**.
 
-The Daily and Weekly tabs use the `folders` config key. Set it to scan multiple folders:
+### Filter types
+
+| Filter | Description |
+|--------|------------|
+| `open` | All open tasks |
+| `overdue` | Tasks past their due date |
+| `caldav` | Tasks synced with CalDAV server |
+| `folder` | Tasks from specific folders (`folders` required) |
+| `timewindow` | Calendar-aligned window: `week` or `month` |
+| `rolling` | N days forward from today (`days` required) |
+| `file` | Tasks from a specific file (`file` required) |
+| `tag` | Tasks with a specific tag (`tag` required) |
+| `wikilink` | Tasks linking to a specific page (`wikilink` required) |
+
+### Config example
 
 ```toml
-[vault]
-folders = ["diary", "journal"]   # shown in Daily + Weekly tabs
+[[ui.tabs]]
+name = "Tasks"
+filter = "open"
+
+[[ui.tabs]]
+name = "Overdue"
+filter = "overdue"
+
+[[ui.tabs]]
+name = "CalDAV"
+filter = "caldav"
+show_done = true    # include completed CalDAV tasks
+
+[[ui.tabs]]
+name = "Diary"
+filter = "folder"
+folders = ["diary"]
+
+[[ui.tabs]]
+name = "Weekly"
+filter = "timewindow"
+window = "week"
+folders = ["diary"]
+
+[[ui.tabs]]
+name = "This Month"
+filter = "timewindow"
+window = "month"
+folders = ["diary"]
+
+[[ui.tabs]]
+name = "Next 14 Days"
+filter = "rolling"
+days = 14
+folders = ["diary"]
+
+[[ui.tabs]]
+name = "DSA"
+filter = "file"
+file = "dsa.md"
+
+[[ui.tabs]]
+name = "Urgent"
+filter = "tag"
+tag = "urgent"
 ```
 
-If `folders` is not set, it falls back to `daily_notes_folder`.
+### Time window options
+
+For `filter = "timewindow"`:
+
+- `window = "week"` — current calendar week (aligned to `week_start`): `sunday` (default) or `monday`
+- `window = "month"` — current calendar month
+
+### Rolling options
+
+For `filter = "rolling"`:
+
+- `days = 14` — N days forward from today
+
+Both `timewindow` and `rolling` match against task **due dates** AND **folder filenames** (e.g., `diary/2026-04-25.md`). If `folders` is not set, filename-date matching is disabled and a warning appears in the tab.
+
+### Show done tasks
+
+By default, done tasks are hidden. Set `show_done = true` on any tab to include completed tasks.
 
 ---
 

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -18,7 +18,9 @@ type RemoteTodo struct {
 	Status      string
 	Summary     string
 	Description string
+	Start       *time.Time
 	Due         *time.Time
+	RRule       string
 	Priority    int
 }
 
@@ -100,7 +102,9 @@ var (
 	summaryRe     = regexp.MustCompile(`(?m)^SUMMARY:(.+)$`)
 	descriptionRe = regexp.MustCompile(`(?m)^DESCRIPTION:(.+)$`)
 	priorityRe    = regexp.MustCompile(`(?m)^PRIORITY:(.+)$`)
+	startRe       = regexp.MustCompile(`(?m)^DTSTART(?:;VALUE=DATE)?:(.+)$`)
 	dueRe         = regexp.MustCompile(`(?m)^DUE(?:;VALUE=DATE)?:(.+)$`)
+	rruleRe       = regexp.MustCompile(`(?m)^RRULE:(.+)$`)
 )
 
 func parseCalendarResponse(body string) []RemoteTodo {
@@ -135,8 +139,14 @@ func parseCalendarResponse(body string) []RemoteTodo {
 		if sm := priorityRe.FindStringSubmatch(raw); sm != nil {
 			fmt.Sscanf(strings.TrimSpace(sm[1]), "%d", &todo.Priority)
 		}
+		if sm := startRe.FindStringSubmatch(raw); sm != nil {
+			todo.Start = parseICalDate(strings.TrimSpace(sm[1]))
+		}
 		if sm := dueRe.FindStringSubmatch(raw); sm != nil {
 			todo.Due = parseICalDate(strings.TrimSpace(sm[1]))
+		}
+		if sm := rruleRe.FindStringSubmatch(raw); sm != nil {
+			todo.RRule = strings.TrimSpace(sm[1])
 		}
 
 		todos = append(todos, todo)

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -102,8 +102,8 @@ var (
 	summaryRe     = regexp.MustCompile(`(?m)^SUMMARY:(.+)$`)
 	descriptionRe = regexp.MustCompile(`(?m)^DESCRIPTION:(.+)$`)
 	priorityRe    = regexp.MustCompile(`(?m)^PRIORITY:(.+)$`)
-	startRe       = regexp.MustCompile(`(?m)^DTSTART(?:;VALUE=DATE)?:(.+)$`)
-	dueRe         = regexp.MustCompile(`(?m)^DUE(?:;VALUE=DATE)?:(.+)$`)
+	startRe       = regexp.MustCompile(`(?m)^DTSTART(?:;[^:]*)?:(.+)$`)
+	dueRe         = regexp.MustCompile(`(?m)^DUE(?:;[^:]*)?:(.+)$`)
 	rruleRe       = regexp.MustCompile(`(?m)^RRULE:(.+)$`)
 )
 

--- a/internal/caldav/client_parse_test.go
+++ b/internal/caldav/client_parse_test.go
@@ -1,0 +1,35 @@
+package caldav
+
+import "testing"
+
+func TestParseCalendarResponse_StartAndRRule(t *testing.T) {
+	body := `<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+<d:response>
+<d:propstat><d:prop><c:calendar-data>BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:abc-123
+SUMMARY:Recurring task
+STATUS:NEEDS-ACTION
+DTSTART;VALUE=DATE:20260601
+DUE;VALUE=DATE:20260602
+RRULE:FREQ=WEEKLY
+PRIORITY:5
+END:VTODO
+END:VCALENDAR</c:calendar-data></d:prop></d:propstat>
+</d:response>
+</d:multistatus>`
+
+	todos := parseCalendarResponse(body)
+	if len(todos) != 1 {
+		t.Fatalf("expected 1 todo, got %d", len(todos))
+	}
+
+	td := todos[0]
+	if td.Start == nil || td.Start.Format("2006-01-02") != "2026-06-01" {
+		t.Fatalf("unexpected start: %v", td.Start)
+	}
+	if td.RRule != "FREQ=WEEKLY" {
+		t.Fatalf("unexpected rrule: %q", td.RRule)
+	}
+}

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -69,7 +69,7 @@ func taskKey(t *task.Task) string {
 
 // PushTask pushes a single task to CalDAV, generating a UID if needed.
 // description is an optional long-form body separate from the task summary.
-func PushTask(cfg config.CalDAV, t *task.Task, due *time.Time, priority int, status, description string) (string, error) {
+func PushTask(cfg config.CalDAV, t *task.Task, start, due *time.Time, rrule string, priority int, status, description string) (string, error) {
 	uidMap, err := LoadUIDMap()
 	if err != nil {
 		return "", fmt.Errorf("loading sync map: %w", err)
@@ -85,7 +85,7 @@ func PushTask(cfg config.CalDAV, t *task.Task, due *time.Time, priority int, sta
 		uid = t.CalDAVUID
 	}
 
-	icsData := BuildVTodo(uid, t.Description, description, due, priority, status)
+	icsData := BuildVTodo(uid, t.Description, description, start, due, rrule, priority, status)
 	if err := PushTodo(cfg, uid, icsData); err != nil {
 		return "", err
 	}

--- a/internal/caldav/vtodo.go
+++ b/internal/caldav/vtodo.go
@@ -66,5 +66,5 @@ func formatDate(t time.Time) string {
 }
 
 func formatDateTime(t time.Time) string {
-	return t.Format("20060102T150405Z")
+	return t.UTC().Format("20060102T150405Z")
 }

--- a/internal/caldav/vtodo.go
+++ b/internal/caldav/vtodo.go
@@ -10,7 +10,7 @@ import (
 // priority: 0 = omit, 1-9 per RFC 5545 (1=highest, 9=lowest).
 // status: defaults to "NEEDS-ACTION" if empty.
 // description: optional long-form body, separate from summary.
-func BuildVTodo(uid, summary, description string, due *time.Time, priority int, status string) string {
+func BuildVTodo(uid, summary, description string, start, due *time.Time, rrule string, priority int, status string) string {
 	now := formatDateTime(time.Now())
 
 	if status == "" {
@@ -36,12 +36,24 @@ func BuildVTodo(uid, summary, description string, due *time.Time, priority int, 
 		fmt.Fprintf(&b, "PRIORITY:%d\r\n", priority)
 	}
 
+	if start != nil {
+		if start.Hour() == 0 && start.Minute() == 0 && start.Second() == 0 {
+			fmt.Fprintf(&b, "DTSTART;VALUE=DATE:%s\r\n", formatDate(*start))
+		} else {
+			fmt.Fprintf(&b, "DTSTART:%s\r\n", formatDateTime(*start))
+		}
+	}
+
 	if due != nil {
 		if due.Hour() == 0 && due.Minute() == 0 && due.Second() == 0 {
 			fmt.Fprintf(&b, "DUE;VALUE=DATE:%s\r\n", formatDate(*due))
 		} else {
 			fmt.Fprintf(&b, "DUE:%s\r\n", formatDateTime(*due))
 		}
+	}
+
+	if rrule != "" {
+		fmt.Fprintf(&b, "RRULE:%s\r\n", rrule)
 	}
 
 	b.WriteString("END:VTODO\r\n")

--- a/internal/caldav/vtodo_test.go
+++ b/internal/caldav/vtodo_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestBuildVTodoNoDue(t *testing.T) {
-	ics := BuildVTodo("test-uid-123", "Buy groceries", "", nil, 0, "")
+	ics := BuildVTodo("test-uid-123", "Buy groceries", "", nil, nil, "", 0, "")
 
 	if !strings.Contains(ics, "UID:test-uid-123") {
 		t.Error("missing UID")
@@ -28,7 +28,7 @@ func TestBuildVTodoNoDue(t *testing.T) {
 
 func TestBuildVTodoWithDateDue(t *testing.T) {
 	due := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
-	ics := BuildVTodo("uid-1", "Deploy fix", "", &due, 0, "")
+	ics := BuildVTodo("uid-1", "Deploy fix", "", nil, &due, "", 0, "")
 
 	if !strings.Contains(ics, "DUE;VALUE=DATE:20260401") {
 		t.Errorf("expected date-only DUE, got: %s", ics)
@@ -37,7 +37,7 @@ func TestBuildVTodoWithDateDue(t *testing.T) {
 
 func TestBuildVTodoWithDateTimeDue(t *testing.T) {
 	due := time.Date(2026, 4, 1, 14, 30, 0, 0, time.UTC)
-	ics := BuildVTodo("uid-2", "Meeting", "", &due, 0, "")
+	ics := BuildVTodo("uid-2", "Meeting", "", nil, &due, "", 0, "")
 
 	if !strings.Contains(ics, "DUE:20260401T143000Z") {
 		t.Errorf("expected datetime DUE, got: %s", ics)
@@ -45,7 +45,7 @@ func TestBuildVTodoWithDateTimeDue(t *testing.T) {
 }
 
 func TestBuildVTodoWithPriority(t *testing.T) {
-	ics := BuildVTodo("uid-3", "Urgent task", "", nil, 5, "")
+	ics := BuildVTodo("uid-3", "Urgent task", "", nil, nil, "", 5, "")
 
 	if !strings.Contains(ics, "PRIORITY:5") {
 		t.Errorf("expected PRIORITY:5, got: %s", ics)
@@ -56,7 +56,7 @@ func TestBuildVTodoWithPriority(t *testing.T) {
 }
 
 func TestBuildVTodoWithCustomStatus(t *testing.T) {
-	ics := BuildVTodo("uid-4", "In progress task", "", nil, 0, "IN-PROCESS")
+	ics := BuildVTodo("uid-4", "In progress task", "", nil, nil, "", 0, "IN-PROCESS")
 
 	if !strings.Contains(ics, "STATUS:IN-PROCESS") {
 		t.Errorf("expected STATUS:IN-PROCESS, got: %s", ics)
@@ -68,7 +68,7 @@ func TestBuildVTodoWithCustomStatus(t *testing.T) {
 
 func TestBuildVTodoWithAllOptions(t *testing.T) {
 	due := time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)
-	ics := BuildVTodo("uid-5", "Full task", "", &due, 1, "COMPLETED")
+	ics := BuildVTodo("uid-5", "Full task", "", nil, &due, "", 1, "COMPLETED")
 
 	if !strings.Contains(ics, "STATUS:COMPLETED") {
 		t.Errorf("expected STATUS:COMPLETED, got: %s", ics)
@@ -78,5 +78,17 @@ func TestBuildVTodoWithAllOptions(t *testing.T) {
 	}
 	if !strings.Contains(ics, "DUE;VALUE=DATE:20260515") {
 		t.Errorf("expected DUE date, got: %s", ics)
+	}
+}
+
+func TestBuildVTodoWithStartAndRRule(t *testing.T) {
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	ics := BuildVTodo("uid-6", "Recurring", "", &start, nil, "FREQ=WEEKLY", 0, "")
+
+	if !strings.Contains(ics, "DTSTART;VALUE=DATE:20260601") {
+		t.Errorf("expected date-only DTSTART, got: %s", ics)
+	}
+	if !strings.Contains(ics, "RRULE:FREQ=WEEKLY") {
+		t.Errorf("expected RRULE, got: %s", ics)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 type Vault struct {
 	Path             string   `toml:"path"`
 	DailyNotesFolder string   `toml:"daily_notes_folder"` // kept for backward compat
-	Folders          []string `toml:"folders"`             // generic folder list; takes precedence over daily_notes_folder
+	Folders          []string `toml:"folders"`            // generic folder list; takes precedence over daily_notes_folder
 	DailyNotesFormat string   `toml:"daily_notes_format"`
 	DefaultTaskFile  string   `toml:"default_task_file"`
 	AddTaskTarget    string   `toml:"add_task_target"`   // "daily" | "default" | vault-relative path
@@ -27,9 +27,23 @@ type CalDAV struct {
 	AutoPush bool   `toml:"auto_push"`
 }
 
+type TabConfig struct {
+	Name      string   `toml:"name"`
+	Filter    string   `toml:"filter"`     // open|folder|file|timewindow|rolling|overdue|caldav|tag|wikilink
+	File      string   `toml:"file"`       // filter="file": vault-relative path
+	Folders   []string `toml:"folders"`    // folder-based filters: vault-relative folder names
+	Window    string   `toml:"window"`     // filter="timewindow": "week" | "month"
+	WeekStart string   `toml:"week_start"` // filter="timewindow" window="week": "sunday"(default)|"monday"
+	Days      int      `toml:"days"`       // filter="rolling": number of days forward from today
+	Tag       string   `toml:"tag"`        // filter="tag": hashtag to match (# prefix optional)
+	WikiLink  string   `toml:"wikilink"`   // filter="wikilink": exact inner text of [[...]]
+	ShowDone  bool     `toml:"show_done"`  // if true, include completed tasks (default false)
+}
+
 type UI struct {
-	DefaultTab string `toml:"default_tab"`
-	Grouped    bool   `toml:"grouped"`
+	DefaultTab string      `toml:"default_tab"`
+	Grouped    bool        `toml:"grouped"`
+	Tabs       []TabConfig `toml:"tabs"`
 }
 
 type Config struct {
@@ -50,6 +64,7 @@ func DefaultConfig() Config {
 		},
 		UI: UI{
 			DefaultTab: "tasks",
+			// Tabs intentionally empty - Load() injects defaults when absent.
 		},
 	}
 }
@@ -89,6 +104,13 @@ func Load() (Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			if len(cfg.UI.Tabs) == 0 {
+				cfg.UI.Tabs = []TabConfig{
+					{Name: "Tasks", Filter: "open"},
+					{Name: "Overdue", Filter: "overdue"},
+					{Name: "CalDAV", Filter: "caldav"},
+				}
+			}
 			return cfg, nil
 		}
 		return cfg, fmt.Errorf("reading config: %w", err)
@@ -96,6 +118,14 @@ func Load() (Config, error) {
 
 	if err := toml.Unmarshal(data, &cfg); err != nil {
 		return cfg, fmt.Errorf("parsing config: %w", err)
+	}
+
+	if len(cfg.UI.Tabs) == 0 {
+		cfg.UI.Tabs = []TabConfig{
+			{Name: "Tasks", Filter: "open"},
+			{Name: "Overdue", Filter: "overdue"},
+			{Name: "CalDAV", Filter: "caldav"},
+		}
 	}
 
 	return cfg, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,14 @@ type Config struct {
 	UI     UI     `toml:"ui"`
 }
 
+func defaultTabs() []TabConfig {
+	return []TabConfig{
+		{Name: "Tasks", Filter: "open"},
+		{Name: "Overdue", Filter: "overdue"},
+		{Name: "CalDAV", Filter: "caldav"},
+	}
+}
+
 func DefaultConfig() Config {
 	return Config{
 		Vault: Vault{
@@ -104,13 +112,7 @@ func Load() (Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if len(cfg.UI.Tabs) == 0 {
-				cfg.UI.Tabs = []TabConfig{
-					{Name: "Tasks", Filter: "open"},
-					{Name: "Overdue", Filter: "overdue"},
-					{Name: "CalDAV", Filter: "caldav"},
-				}
-			}
+			cfg.UI.Tabs = defaultTabs()
 			return cfg, nil
 		}
 		return cfg, fmt.Errorf("reading config: %w", err)
@@ -121,11 +123,7 @@ func Load() (Config, error) {
 	}
 
 	if len(cfg.UI.Tabs) == 0 {
-		cfg.UI.Tabs = []TabConfig{
-			{Name: "Tasks", Filter: "open"},
-			{Name: "Overdue", Filter: "overdue"},
-			{Name: "CalDAV", Filter: "caldav"},
-		}
+		cfg.UI.Tabs = defaultTabs()
 	}
 
 	return cfg, nil

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -28,6 +28,8 @@ type Task struct {
 	Description    string
 	Status         Status
 	Due            *time.Time
+	Start          *time.Time
+	RRule          string
 	Tags           []string
 	WikiLinks      []string
 	Source         Source

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -461,9 +461,11 @@ func (a App) handleAddFormKey(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if a.addForm.Submitted() {
 		summary := a.addForm.GetSummary()
 		target := a.addForm.GetTarget()
+		start := a.addForm.GetStart()
 		due := a.addForm.GetDue()
 		priority := a.addForm.GetPriority()
 		status := a.addForm.GetStatus()
+		rrule := a.addForm.GetRRule()
 		description := a.addForm.GetDescription()
 		push := a.addForm.GetPush()
 		cfg := a.ctx.Config
@@ -472,13 +474,13 @@ func (a App) handleAddFormKey(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if a.addFormTask != nil {
 			// p key path: link an existing plain task
-			return a, LinkExistingTaskCmd(a.addFormTask, summary, description, due, priority, status, push, cfg)
+			return a, LinkExistingTaskCmd(a.addFormTask, summary, description, start, due, priority, status, rrule, push, cfg)
 		}
 
 		// a key path: create new task
 		vcfg := cfg.Vault
 		filePath := vault.ResolveTaskFile(vcfg.Path, vcfg.DailyNotesFolder, vcfg.DailyNotesFormat, vcfg.DefaultTaskFile, target)
-		return a, AddTaskWithMetaCmd(filePath, summary, description, due, priority, status, push, cfg)
+		return a, AddTaskWithMetaCmd(filePath, summary, description, start, due, priority, status, rrule, push, cfg)
 	}
 
 	return a, cmd
@@ -496,15 +498,17 @@ func (a App) handleEditFormKey(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if a.editForm.Submitted() {
 		summary := a.editForm.GetSummary()
+		start := a.editForm.GetStart()
 		due := a.editForm.GetDue()
 		priority := a.editForm.GetPriority()
 		status := a.editForm.GetStatus()
+		rrule := a.editForm.GetRRule()
 		description := a.editForm.GetDescription()
 		push := a.editForm.GetPush()
 		cfg := a.ctx.Config
 
 		a.mode = modeBrowser
-		return a, EditTaskCmd(a.editFormTask, summary, description, due, priority, status, push, cfg)
+		return a, EditTaskCmd(a.editFormTask, summary, description, start, due, priority, status, rrule, push, cfg)
 	}
 
 	return a, cmd

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -68,11 +68,13 @@ func NewApp(cfg config.Config) App {
 	if len(dfs) == 0 && cfg.Vault.DailyNotesFolder != "" {
 		dfs = []string{cfg.Vault.DailyNotesFolder}
 	}
-	_ = dfs
 
 	var sections []section.Section
 	for _, tab := range cfg.UI.Tabs {
 		tabFolders := tab.Folders
+		if len(tabFolders) == 0 {
+			tabFolders = dfs
+		}
 
 		var fn tasksection.FilterFunc
 		var warningParts []string
@@ -268,7 +270,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.message = "Editor error: " + msg.Err.Error()
 		}
 		a.loading = true
+		a.loadedFromScan = false
 		return a, tea.Batch(
+			LoadCacheCmd(a.cachePath),
 			LoadTasksCmd(a.ctx.VaultPath(), a.ctx.Config.Vault.TaskFilesFolder, a.cachePath),
 			a.spinner.Tick,
 		)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -43,10 +43,10 @@ type App struct {
 	input     string
 	message   string
 
-	allTasks  []task.Task
-	sections  []section.Section
-	activeTab int
-	cursor    int
+	allTasks       []task.Task
+	sections       []section.Section
+	activeTab      int
+	cursor         int
 	loading        bool
 	loadedFromScan bool
 	cachePath      string
@@ -68,13 +68,66 @@ func NewApp(cfg config.Config) App {
 	if len(dfs) == 0 && cfg.Vault.DailyNotesFolder != "" {
 		dfs = []string{cfg.Vault.DailyNotesFolder}
 	}
+	_ = dfs
 
-	sections := []section.Section{
-		tasksection.New("Tasks",   vp, dfs, dfmt, tasksection.FilterOpen),
-		tasksection.New("Daily",   vp, dfs, dfmt, tasksection.FilterDailyFolders),
-		tasksection.New("Weekly",  vp, dfs, dfmt, tasksection.FilterWeekly),
-		tasksection.New("Overdue", vp, dfs, dfmt, tasksection.FilterOverdue),
-		tasksection.New("CalDAV",  vp, dfs, dfmt, tasksection.FilterCalDAV),
+	var sections []section.Section
+	for _, tab := range cfg.UI.Tabs {
+		tabFolders := tab.Folders
+
+		var fn tasksection.FilterFunc
+		var warningParts []string
+
+		switch tab.Filter {
+		case "open":
+			fn = tasksection.FilterOpen
+		case "folder":
+			fn = tasksection.MakeFolderFilter(vp, tabFolders)
+		case "timewindow":
+			if len(tabFolders) == 0 {
+				warningParts = append(warningParts, "no folders set - filename-date matching disabled")
+			}
+			fn = tasksection.MakeTimeWindowFilter(vp, tabFolders, dfmt, tab.Window, tab.WeekStart)
+		case "rolling":
+			if tab.Days == 0 {
+				warningParts = append(warningParts, "days must be > 0")
+			}
+			if len(tabFolders) == 0 {
+				warningParts = append(warningParts, "no folders set - filename-date matching disabled")
+			}
+			fn = tasksection.MakeRollingFilter(vp, tabFolders, dfmt, tab.Days)
+		case "overdue":
+			fn = tasksection.FilterOverdue
+		case "caldav":
+			fn = tasksection.FilterCalDAV
+		case "file":
+			fn = tasksection.MakeFileFilter(vp, tab.File)
+		case "tag":
+			fn = tasksection.MakeTagFilter(tab.Tag)
+		case "wikilink":
+			fn = tasksection.MakeWikiLinkFilter(tab.WikiLink)
+		default:
+			fn = tasksection.FilterOpen
+		}
+
+		if !tab.ShowDone {
+			inner := fn
+			fn = func(tasks []task.Task) []task.Task {
+				all := inner(tasks)
+				out := make([]task.Task, 0, len(all))
+				for _, t := range all {
+					if !t.IsDone() {
+						out = append(out, t)
+					}
+				}
+				return out
+			}
+		}
+
+		s := tasksection.New(tab.Name, vp, fn)
+		if len(warningParts) > 0 {
+			s.SetWarning(strings.Join(warningParts, "; "))
+		}
+		sections = append(sections, s)
 	}
 
 	if cfg.UI.Grouped {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -72,7 +72,7 @@ func ToggleTaskCmd(t *task.Task, caldavCfg config.CalDAV) tea.Cmd {
 			_ = vault.UpdateTaskFileStatus(t.LinkedTaskFile, newStatus)
 
 			if caldavCfg.URL != "" {
-				_, pushErr := caldav.PushTask(caldavCfg, t, t.Due, 0, newStatus, "")
+				_, pushErr := caldav.PushTask(caldavCfg, t, t.Start, t.Due, t.RRule, 0, newStatus, "")
 				if pushErr != nil {
 					return TaskToggledMsg{Task: t, CalDAVErr: pushErr}
 				}
@@ -95,9 +95,10 @@ func AddTaskCmd(filePath, description string) tea.Cmd {
 // and optionally pushes to CalDAV.
 func AddTaskWithMetaCmd(
 	filePath, summary, description string,
-	due *time.Time,
+	start, due *time.Time,
 	priority int,
 	status string,
+	rrule string,
 	push bool,
 	cfg config.Config,
 ) tea.Cmd {
@@ -109,7 +110,7 @@ func AddTaskWithMetaCmd(
 
 		if push && cfg.CalDAV.URL != "" {
 			tmpTask := &task.Task{Description: summary, CalDAVUID: uid}
-			uid2, err := caldav.PushTask(cfg.CalDAV, tmpTask, due, priority, status, description)
+			uid2, err := caldav.PushTask(cfg.CalDAV, tmpTask, start, due, rrule, priority, status, description)
 			if err != nil {
 				pushErr = err
 			} else {
@@ -117,7 +118,7 @@ func AddTaskWithMetaCmd(
 			}
 		}
 
-		if err := vault.CreateTaskFile(taskFilesDir, uid, summary, description, due, priority, status); err != nil {
+		if err := vault.CreateTaskFile(taskFilesDir, uid, summary, description, start, due, rrule, priority, status); err != nil {
 			return TaskAddedMsg{Description: summary, Err: err}
 		}
 
@@ -141,9 +142,10 @@ func AddTaskWithMetaCmd(
 func LinkExistingTaskCmd(
 	t *task.Task,
 	summary, description string,
-	due *time.Time,
+	start, due *time.Time,
 	priority int,
 	status string,
+	rrule string,
 	push bool,
 	cfg config.Config,
 ) tea.Cmd {
@@ -155,7 +157,7 @@ func LinkExistingTaskCmd(
 
 		if push && cfg.CalDAV.URL != "" {
 			pushTask := &task.Task{Description: summary, CalDAVUID: uid}
-			uid2, err := caldav.PushTask(cfg.CalDAV, pushTask, due, priority, status, description)
+			uid2, err := caldav.PushTask(cfg.CalDAV, pushTask, start, due, rrule, priority, status, description)
 			if err != nil {
 				pushErr = err
 			} else {
@@ -163,7 +165,7 @@ func LinkExistingTaskCmd(
 			}
 		}
 
-		if err := vault.CreateTaskFile(taskFilesDir, uid, summary, description, due, priority, status); err != nil {
+		if err := vault.CreateTaskFile(taskFilesDir, uid, summary, description, start, due, rrule, priority, status); err != nil {
 			return TaskAddedMsg{Description: summary, Err: err}
 		}
 
@@ -205,13 +207,13 @@ func PullCalDAVCmd(cfg config.Config) tea.Cmd {
 			taskFile := filepath.Join(taskFilesDir, todo.UID+".md")
 
 			if _, statErr := os.Stat(taskFile); statErr == nil {
-				if err := vault.UpdateTaskFileFrontmatter(taskFile, todo.Due, todo.Status, todo.Priority); err != nil {
+				if err := vault.UpdateTaskFileFrontmatter(taskFile, todo.Start, todo.Due, todo.RRule, todo.Status, todo.Priority); err != nil {
 					fileErrs++
 				} else {
 					updated++
 				}
 			} else {
-				if err := vault.CreateTaskFile(taskFilesDir, todo.UID, todo.Summary, todo.Description, todo.Due, todo.Priority, todo.Status); err != nil {
+				if err := vault.CreateTaskFile(taskFilesDir, todo.UID, todo.Summary, todo.Description, todo.Start, todo.Due, todo.RRule, todo.Priority, todo.Status); err != nil {
 					fileErrs++
 					continue
 				}
@@ -237,7 +239,7 @@ func PullCalDAVCmd(cfg config.Config) tea.Cmd {
 // PushCalDAVCmd pushes an existing task to CalDAV via the push form.
 func PushCalDAVCmd(cfg config.CalDAV, t *task.Task) tea.Cmd {
 	return func() tea.Msg {
-		uid, err := caldav.PushTask(cfg, t, nil, 0, "", "")
+		uid, err := caldav.PushTask(cfg, t, t.Start, t.Due, t.RRule, 0, "", "")
 		return CalDAVPushedMsg{Task: t, UID: uid, Err: err}
 	}
 }
@@ -250,14 +252,15 @@ func PushCalDAVCmd(cfg config.CalDAV, t *task.Task) tea.Cmd {
 func EditTaskCmd(
 	t *task.Task,
 	newSummary, body string,
-	due *time.Time,
+	start, due *time.Time,
 	priority int,
 	status string,
+	rrule string,
 	push bool,
 	cfg config.Config,
 ) tea.Cmd {
 	return func() tea.Msg {
-		hasMetadata := due != nil || priority > 0 || status != "" || body != ""
+		hasMetadata := start != nil || due != nil || rrule != "" || priority > 0 || status != "" || body != ""
 
 		// Plain task with no metadata change → simple description rewrite
 		if t.LinkedTaskFile == "" && !hasMetadata {
@@ -277,7 +280,7 @@ func EditTaskCmd(
 
 			if push && cfg.CalDAV.URL != "" {
 				pushTask := &task.Task{Description: newSummary, CalDAVUID: uid}
-				uid2, err := caldav.PushTask(cfg.CalDAV, pushTask, due, priority, status, body)
+				uid2, err := caldav.PushTask(cfg.CalDAV, pushTask, start, due, rrule, priority, status, body)
 				if err != nil {
 					caldavErr = err
 				} else {
@@ -285,7 +288,7 @@ func EditTaskCmd(
 				}
 			}
 
-			if err := vault.CreateTaskFile(taskFilesDir, uid, newSummary, body, due, priority, status); err != nil {
+			if err := vault.CreateTaskFile(taskFilesDir, uid, newSummary, body, start, due, rrule, priority, status); err != nil {
 				return TaskEditedMsg{Task: t, Err: err}
 			}
 			if err := vault.RewriteTaskLine(t.Source.FilePath, t.Source.Line, uid, newSummary); err != nil {
@@ -296,7 +299,7 @@ func EditTaskCmd(
 		}
 
 		// Linked task → update task file in one pass
-		if err := vault.UpdateTaskFileContent(t.LinkedTaskFile, newSummary, body, due, status, priority); err != nil {
+		if err := vault.UpdateTaskFileContent(t.LinkedTaskFile, newSummary, body, start, due, rrule, status, priority); err != nil {
 			return TaskEditedMsg{Task: t, Err: err}
 		}
 		if newSummary != t.Description {
@@ -309,9 +312,9 @@ func EditTaskCmd(
 		// Push if already synced to CalDAV (auto-push, no toggle needed)
 		var caldavErr error
 		if t.CalDAVUID != "" && cfg.CalDAV.URL != "" {
-			_, caldavErr = caldav.PushTask(cfg.CalDAV, t, due, priority, status, body)
+			_, caldavErr = caldav.PushTask(cfg.CalDAV, t, start, due, rrule, priority, status, body)
 		} else if push && cfg.CalDAV.URL != "" {
-			uid, err := caldav.PushTask(cfg.CalDAV, t, due, priority, status, body)
+			uid, err := caldav.PushTask(cfg.CalDAV, t, start, due, rrule, priority, status, body)
 			if err != nil {
 				caldavErr = err
 			} else {

--- a/internal/tui/components/addform/model.go
+++ b/internal/tui/components/addform/model.go
@@ -15,6 +15,8 @@ var (
 	priorityOptions = []string{"none", "1 (highest)", "5 (normal)", "9 (lowest)"}
 	priorityValues  = []int{0, 1, 5, 9}
 	statusOptions   = []string{"NEEDS-ACTION", "IN-PROCESS", "COMPLETED", "CANCELLED"}
+	repeatOptions   = []string{"none", "daily", "weekly", "monthly", "yearly"}
+	repeatRules     = []string{"", "FREQ=DAILY", "FREQ=WEEKLY", "FREQ=MONTHLY", "FREQ=YEARLY"}
 	pushOptions     = []string{"No", "Yes"}
 
 	formStyle = lipgloss.NewStyle().
@@ -67,12 +69,15 @@ const pickerMaxVisible = 5
 const (
 	fieldSummary     = 0
 	fieldTarget      = 1
-	fieldDueDate     = 2
-	fieldDueTime     = 3
-	fieldDescription = 4
-	fieldPriority    = 5
-	fieldStatus      = 6
-	fieldPush        = 7 // only when showPush
+	fieldStartDate   = 2
+	fieldStartTime   = 3
+	fieldDueDate     = 4
+	fieldDueTime     = 5
+	fieldDescription = 6
+	fieldPriority    = 7
+	fieldStatus      = 8
+	fieldRepeat      = 9
+	fieldPush        = 10 // only when showPush
 )
 
 // Model is the add task form component.
@@ -85,11 +90,14 @@ type Model struct {
 	pickerCur   int
 	pickerOff   int
 	ctrlXMode   bool
+	startDate   textinput.Model
+	startTime   textinput.Model
 	dueDate     textinput.Model
 	dueTime     textinput.Model
 	description textinput.Model
 	priority    int
 	status      int
+	repeat      int
 	push        int
 	showPush    bool
 	focusIndex  int
@@ -135,6 +143,18 @@ func New(summary string, targets []string, defaultTargetIdx int, defaultPush boo
 	desc.CharLimit = 500
 	desc.Width = 40
 
+	sd := textinput.New()
+	sd.Placeholder = "YYYY-MM-DD"
+	sd.Prompt = ""
+	sd.CharLimit = 10
+	sd.Width = 12
+
+	st := textinput.New()
+	st.Placeholder = "HH:MM"
+	st.Prompt = ""
+	st.CharLimit = 5
+	st.Width = 7
+
 	pushVal := 0
 	if defaultPush {
 		pushVal = 1
@@ -145,11 +165,14 @@ func New(summary string, targets []string, defaultTargetIdx int, defaultPush boo
 		targetInput: ti,
 		targets:     targets,
 		targetSel:   defaultTargetIdx,
+		startDate:   sd,
+		startTime:   st,
 		dueDate:     dd,
 		dueTime:     dt,
 		description: desc,
 		priority:    0,
 		status:      0,
+		repeat:      0,
 		push:        pushVal,
 		showPush:    showPush,
 		focusIndex:  fieldSummary,
@@ -160,9 +183,9 @@ func New(summary string, targets []string, defaultTargetIdx int, defaultPush boo
 
 func (m *Model) numFields() int {
 	if m.showPush {
-		return 8
+		return 11
 	}
-	return 7
+	return 10
 }
 
 func (m *Model) rebuildPicker() {
@@ -197,6 +220,8 @@ func (m *Model) syncPickerOffset() {
 func (m *Model) updateFocus() {
 	m.summary.Blur()
 	m.targetInput.Blur()
+	m.startDate.Blur()
+	m.startTime.Blur()
 	m.dueDate.Blur()
 	m.dueTime.Blur()
 	m.description.Blur()
@@ -206,6 +231,10 @@ func (m *Model) updateFocus() {
 		m.summary.Focus()
 	case fieldTarget:
 		m.targetInput.Focus()
+	case fieldStartDate:
+		m.startDate.Focus()
+	case fieldStartTime:
+		m.startTime.Focus()
 	case fieldDueDate:
 		m.dueDate.Focus()
 	case fieldDueTime:
@@ -240,7 +269,7 @@ func (m *Model) selectTargetByName(name string) {
 // isTextField returns true for fields that take text input (no y/n shortcuts).
 func (m *Model) isTextField() bool {
 	switch m.focusIndex {
-	case fieldSummary, fieldTarget, fieldDueDate, fieldDueTime, fieldDescription:
+	case fieldSummary, fieldTarget, fieldStartDate, fieldStartTime, fieldDueDate, fieldDueTime, fieldDescription:
 		return true
 	}
 	return false
@@ -307,7 +336,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			}
 			if m.focusIndex == fieldTarget {
 				m.confirmTargetSelection()
-				m.focusIndex = fieldDueDate
+				m.focusIndex = fieldStartDate
 				m.updateFocus()
 				return m, nil
 			}
@@ -330,6 +359,13 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 					m.status = (m.status + 1) % len(statusOptions)
 				} else {
 					m.status = (m.status - 1 + len(statusOptions)) % len(statusOptions)
+				}
+				return m, nil
+			case fieldRepeat:
+				if k == "right" {
+					m.repeat = (m.repeat + 1) % len(repeatOptions)
+				} else {
+					m.repeat = (m.repeat - 1 + len(repeatOptions)) % len(repeatOptions)
 				}
 				return m, nil
 			case fieldPush:
@@ -372,6 +408,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		switch m.focusIndex {
 		case fieldSummary:
 			m.summary, cmd = m.summary.Update(msg)
+		case fieldStartDate:
+			m.startDate, cmd = m.startDate.Update(msg)
+		case fieldStartTime:
+			m.startTime, cmd = m.startTime.Update(msg)
 		case fieldDueDate:
 			m.dueDate, cmd = m.dueDate.Update(msg)
 		case fieldDueTime:
@@ -389,6 +429,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.summary, cmd = m.summary.Update(msg)
 	case fieldTarget:
 		m.targetInput, cmd = m.targetInput.Update(msg)
+	case fieldStartDate:
+		m.startDate, cmd = m.startDate.Update(msg)
+	case fieldStartTime:
+		m.startTime, cmd = m.startTime.Update(msg)
 	case fieldDueDate:
 		m.dueDate, cmd = m.dueDate.Update(msg)
 	case fieldDueTime:
@@ -417,6 +461,21 @@ func (m Model) View() string {
 		b.WriteString("\n")
 	}
 
+	// Start date + time on one line
+	startDateActive := m.focusIndex == fieldStartDate
+	startTimeActive := m.focusIndex == fieldStartTime
+	startLabel := labelStyle.Render("Start:")
+	startDateView := m.startDate.View()
+	startTimeView := m.startTime.View()
+	if !startDateActive {
+		startDateView = inactiveFieldStyle.Render(m.startDate.Value())
+	}
+	if !startTimeActive {
+		startTimeView = inactiveFieldStyle.Render(m.startTime.Value())
+	}
+	b.WriteString(fmt.Sprintf("%s %s  %s", startLabel, startDateView, startTimeView))
+	b.WriteString("\n")
+
 	// Due date + time on one line
 	dateActive := m.focusIndex == fieldDueDate
 	timeActive := m.focusIndex == fieldDueTime
@@ -439,6 +498,9 @@ func (m Model) View() string {
 	b.WriteString("\n")
 
 	b.WriteString(m.renderField("Status", m.renderCycle(statusOptions, m.status, m.focusIndex == fieldStatus), m.focusIndex == fieldStatus))
+	b.WriteString("\n")
+
+	b.WriteString(m.renderField("Repeat", m.renderCycle(repeatOptions, m.repeat, m.focusIndex == fieldRepeat), m.focusIndex == fieldRepeat))
 	b.WriteString("\n")
 
 	if m.showPush {
@@ -553,6 +615,28 @@ func (m Model) GetDue() *time.Time {
 	return &t
 }
 
+// GetStart combines the start date and time fields into a *time.Time.
+// Returns nil if the date field is empty or unparseable.
+func (m Model) GetStart() *time.Time {
+	dateVal := strings.TrimSpace(m.startDate.Value())
+	if dateVal == "" {
+		return nil
+	}
+	t, err := time.ParseInLocation("2006-01-02", dateVal, time.Local)
+	if err != nil {
+		return nil
+	}
+	timeVal := strings.TrimSpace(m.startTime.Value())
+	if timeVal != "" {
+		var h, min int
+		if _, err := fmt.Sscanf(timeVal, "%d:%d", &h, &min); err == nil {
+			t = time.Date(t.Year(), t.Month(), t.Day(), h, min, 0, 0, time.Local)
+		}
+	}
+	return &t
+}
+
 func (m Model) GetPriority() int  { return priorityValues[m.priority] }
 func (m Model) GetStatus() string { return statusOptions[m.status] }
 func (m Model) GetPush() bool     { return m.push == 1 }
+func (m Model) GetRRule() string  { return repeatRules[m.repeat] }

--- a/internal/tui/components/editform/model.go
+++ b/internal/tui/components/editform/model.go
@@ -15,6 +15,8 @@ var (
 	priorityOptions = []string{"none", "1 (highest)", "5 (normal)", "9 (lowest)"}
 	priorityValues  = []int{0, 1, 5, 9}
 	statusOptions   = []string{"NEEDS-ACTION", "IN-PROCESS", "COMPLETED", "CANCELLED"}
+	repeatOptions   = []string{"none", "daily", "weekly", "monthly", "yearly"}
+	repeatRules     = []string{"", "FREQ=DAILY", "FREQ=WEEKLY", "FREQ=MONTHLY", "FREQ=YEARLY"}
 	pushOptions     = []string{"No", "Yes"}
 
 	formStyle = lipgloss.NewStyle().
@@ -47,22 +49,28 @@ var (
 // focusIndex constants
 const (
 	fieldSummary     = 0
-	fieldDueDate     = 1
-	fieldDueTime     = 2
-	fieldDescription = 3
-	fieldPriority    = 4
-	fieldStatus      = 5
-	fieldPush        = 6 // only when showPush
+	fieldStartDate   = 1
+	fieldStartTime   = 2
+	fieldDueDate     = 3
+	fieldDueTime     = 4
+	fieldDescription = 5
+	fieldPriority    = 6
+	fieldStatus      = 7
+	fieldRepeat      = 8
+	fieldPush        = 9 // only when showPush
 )
 
 // Model is the edit task form component.
 type Model struct {
 	summary     textinput.Model
+	startDate   textinput.Model
+	startTime   textinput.Model
 	dueDate     textinput.Model
 	dueTime     textinput.Model
 	description textinput.Model
 	priority    int
 	status      int
+	repeat      int
 	push        int
 	showPush    bool // true when no CalDAV UID yet and CalDAV is configured
 	focusIndex  int
@@ -106,6 +114,24 @@ func New(t *task.Task, showPush bool) Model {
 	desc.Width = 40
 	desc.SetValue(t.Body)
 
+	sd := textinput.New()
+	sd.Placeholder = "YYYY-MM-DD"
+	sd.Prompt = ""
+	sd.CharLimit = 10
+	sd.Width = 12
+	if t.Start != nil {
+		sd.SetValue(t.Start.Format("2006-01-02"))
+	}
+
+	st := textinput.New()
+	st.Placeholder = "HH:MM"
+	st.Prompt = ""
+	st.CharLimit = 5
+	st.Width = 7
+	if t.Start != nil && (t.Start.Hour() != 0 || t.Start.Minute() != 0) {
+		st.SetValue(t.Start.Format("15:04"))
+	}
+
 	// Map task priority to option index
 	priorityIdx := 0
 	for i, v := range priorityValues {
@@ -124,13 +150,24 @@ func New(t *task.Task, showPush bool) Model {
 		}
 	}
 
+	repeatIdx := 0
+	for i, r := range repeatRules {
+		if r == t.RRule {
+			repeatIdx = i
+			break
+		}
+	}
+
 	return Model{
 		summary:     si,
+		startDate:   sd,
+		startTime:   st,
 		dueDate:     dd,
 		dueTime:     dt,
 		description: desc,
 		priority:    priorityIdx,
 		status:      statusIdx,
+		repeat:      repeatIdx,
 		showPush:    showPush,
 		focusIndex:  fieldSummary,
 	}
@@ -138,13 +175,15 @@ func New(t *task.Task, showPush bool) Model {
 
 func (m *Model) numFields() int {
 	if m.showPush {
-		return 7
+		return 10
 	}
-	return 6
+	return 9
 }
 
 func (m *Model) updateFocus() {
 	m.summary.Blur()
+	m.startDate.Blur()
+	m.startTime.Blur()
 	m.dueDate.Blur()
 	m.dueTime.Blur()
 	m.description.Blur()
@@ -152,6 +191,10 @@ func (m *Model) updateFocus() {
 	switch m.focusIndex {
 	case fieldSummary:
 		m.summary.Focus()
+	case fieldStartDate:
+		m.startDate.Focus()
+	case fieldStartTime:
+		m.startTime.Focus()
 	case fieldDueDate:
 		m.dueDate.Focus()
 	case fieldDueTime:
@@ -164,6 +207,8 @@ func (m *Model) updateFocus() {
 func (m *Model) isTextField() bool {
 	switch m.focusIndex {
 	case fieldSummary, fieldDueDate, fieldDueTime, fieldDescription:
+		return true
+	case fieldStartDate, fieldStartTime:
 		return true
 	}
 	return false
@@ -225,6 +270,13 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 					m.status = (m.status - 1 + len(statusOptions)) % len(statusOptions)
 				}
 				return m, nil
+			case fieldRepeat:
+				if k == "right" {
+					m.repeat = (m.repeat + 1) % len(repeatOptions)
+				} else {
+					m.repeat = (m.repeat - 1 + len(repeatOptions)) % len(repeatOptions)
+				}
+				return m, nil
 			case fieldPush:
 				if k == "right" {
 					m.push = (m.push + 1) % len(pushOptions)
@@ -239,6 +291,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		switch m.focusIndex {
 		case fieldSummary:
 			m.summary, cmd = m.summary.Update(msg)
+		case fieldStartDate:
+			m.startDate, cmd = m.startDate.Update(msg)
+		case fieldStartTime:
+			m.startTime, cmd = m.startTime.Update(msg)
 		case fieldDueDate:
 			m.dueDate, cmd = m.dueDate.Update(msg)
 		case fieldDueTime:
@@ -254,6 +310,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch m.focusIndex {
 	case fieldSummary:
 		m.summary, cmd = m.summary.Update(msg)
+	case fieldStartDate:
+		m.startDate, cmd = m.startDate.Update(msg)
+	case fieldStartTime:
+		m.startTime, cmd = m.startTime.Update(msg)
 	case fieldDueDate:
 		m.dueDate, cmd = m.dueDate.Update(msg)
 	case fieldDueTime:
@@ -272,6 +332,21 @@ func (m Model) View() string {
 	b.WriteString("\n")
 
 	b.WriteString(m.renderField("Summary", m.summary.View(), m.focusIndex == fieldSummary))
+	b.WriteString("\n")
+
+	// Start date + time on one line
+	startDateActive := m.focusIndex == fieldStartDate
+	startTimeActive := m.focusIndex == fieldStartTime
+	startLabel := labelStyle.Render("Start:")
+	startDateView := m.startDate.View()
+	startTimeView := m.startTime.View()
+	if !startDateActive {
+		startDateView = inactiveFieldStyle.Render(m.startDate.Value())
+	}
+	if !startTimeActive {
+		startTimeView = inactiveFieldStyle.Render(m.startTime.Value())
+	}
+	b.WriteString(fmt.Sprintf("%s %s  %s", startLabel, startDateView, startTimeView))
 	b.WriteString("\n")
 
 	// Due date + time on one line
@@ -296,6 +371,9 @@ func (m Model) View() string {
 	b.WriteString("\n")
 
 	b.WriteString(m.renderField("Status", m.renderCycle(statusOptions, m.status, m.focusIndex == fieldStatus), m.focusIndex == fieldStatus))
+	b.WriteString("\n")
+
+	b.WriteString(m.renderField("Repeat", m.renderCycle(repeatOptions, m.repeat, m.focusIndex == fieldRepeat), m.focusIndex == fieldRepeat))
 	b.WriteString("\n")
 
 	if m.showPush {
@@ -352,5 +430,27 @@ func (m Model) GetDue() *time.Time {
 	return &t
 }
 
+// GetStart combines the start date and time fields into a *time.Time.
+// Returns nil if the date field is empty or unparseable.
+func (m Model) GetStart() *time.Time {
+	dateVal := strings.TrimSpace(m.startDate.Value())
+	if dateVal == "" {
+		return nil
+	}
+	t, err := time.ParseInLocation("2006-01-02", dateVal, time.Local)
+	if err != nil {
+		return nil
+	}
+	timeVal := strings.TrimSpace(m.startTime.Value())
+	if timeVal != "" {
+		var h, min int
+		if _, err := fmt.Sscanf(timeVal, "%d:%d", &h, &min); err == nil {
+			t = time.Date(t.Year(), t.Month(), t.Day(), h, min, 0, 0, time.Local)
+		}
+	}
+	return &t
+}
+
 func (m Model) GetPriority() int  { return priorityValues[m.priority] }
 func (m Model) GetStatus() string { return statusOptions[m.status] }
+func (m Model) GetRRule() string  { return repeatRules[m.repeat] }

--- a/internal/tui/components/tasksection/model.go
+++ b/internal/tui/components/tasksection/model.go
@@ -2,6 +2,7 @@ package tasksection
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -13,36 +14,35 @@ import (
 )
 
 // FilterFunc decides which tasks belong in this section.
-type FilterFunc func(tasks []task.Task, folders []string, dailyFormat string) []task.Task
+type FilterFunc func(tasks []task.Task) []task.Task
 
 // Model implements section.Section for a filtered task list view.
 type Model struct {
-	title       string
-	filterFn    FilterFunc
-	vaultPath   string
-	folders     []string
-	dailyFormat string
-	filtered    []task.Task
-	search      string
-	grouped     bool
+	title     string
+	filterFn  FilterFunc
+	vaultPath string
+	warning   string
+	filtered  []task.Task
+	search    string
+	grouped   bool
 }
 
 var _ section.Section = (*Model)(nil)
 
-func New(title, vaultPath string, folders []string, dailyFormat string, filterFn FilterFunc) *Model {
+func New(title, vaultPath string, filterFn FilterFunc) *Model {
 	return &Model{
-		title:       title,
-		filterFn:    filterFn,
-		vaultPath:   vaultPath,
-		folders:     folders,
-		dailyFormat: dailyFormat,
+		title:     title,
+		filterFn:  filterFn,
+		vaultPath: vaultPath,
 	}
 }
+
+func (m *Model) SetWarning(w string) { m.warning = w }
 
 func (m *Model) Title() string { return m.title }
 
 func (m *Model) SetTasks(all []task.Task) {
-	m.filtered = m.filterFn(all, m.folders, m.dailyFormat)
+	m.filtered = m.filterFn(all)
 	m.applySearch()
 }
 
@@ -70,14 +70,20 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 }
 
 func (m *Model) View(width, height, cursor int, selected bool) string {
+	var content string
 	if len(m.filtered) == 0 {
-		return "  No tasks\n"
+		content = "  No tasks\n"
+	} else if m.grouped {
+		content = m.viewGrouped(width, height, cursor, selected)
+	} else {
+		content = m.viewFlat(width, height, cursor, selected)
 	}
 
-	if m.grouped {
-		return m.viewGrouped(width, height, cursor, selected)
+	if m.warning != "" {
+		return warningStyle.Render("  ⚠ "+m.warning) + "\n" + content
 	}
-	return m.viewFlat(width, height, cursor, selected)
+
+	return content
 }
 
 func (m *Model) viewFlat(width, height, cursor int, selected bool) string {
@@ -220,80 +226,28 @@ var (
 	selectedStyle   = lipgloss.NewStyle().Background(lipgloss.Color("236")).Bold(true)
 	sourceStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 	fileHeaderStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("170")).Bold(true)
+	warningStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 )
 
 // --- Built-in filter functions ---
 
-func FilterOpen(tasks []task.Task, _ []string, _ string) []task.Task {
+func FilterOpen(tasks []task.Task) []task.Task {
+	return tasks
+}
+
+func FilterOverdue(tasks []task.Task) []task.Task {
+	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	var out []task.Task
 	for i := range tasks {
-		if !tasks[i].IsDone() {
+		if tasks[i].Due != nil && tasks[i].Due.Before(today) {
 			out = append(out, tasks[i])
 		}
 	}
 	return out
 }
 
-func FilterWeekly(tasks []task.Task, folders []string, dailyFormat string) []task.Task {
-	now := time.Now()
-	daysBackToSunday := int(now.Weekday()) // 0=Sun, 1=Mon, …, 6=Sat
-	weekStart := time.Date(now.Year(), now.Month(), now.Day()-daysBackToSunday, 0, 0, 0, 0, now.Location())
-	weekEnd := weekStart.AddDate(0, 0, 7)
-	days := make([]string, 7)
-	for d := 0; d < 7; d++ {
-		days[d] = weekStart.AddDate(0, 0, d).Format(dailyFormat)
-	}
-	var out []task.Task
-outer:
-	for i := range tasks {
-		t := &tasks[i]
-		for _, folder := range folders {
-			for d := 0; d < 7; d++ {
-				if strings.Contains(t.Source.FilePath, "/"+folder+"/"+days[d]) {
-					if !t.IsDone() {
-						out = append(out, *t)
-					}
-					continue outer
-				}
-			}
-		}
-		if t.Due != nil && !t.Due.Before(weekStart) && t.Due.Before(weekEnd) && !t.IsDone() {
-			out = append(out, *t)
-		}
-	}
-	return out
-}
-
-func FilterDailyFolders(tasks []task.Task, folders []string, _ string) []task.Task {
-	var out []task.Task
-	for i := range tasks {
-		t := &tasks[i]
-		for _, folder := range folders {
-			if strings.Contains(t.Source.FilePath, "/"+folder+"/") {
-				if !t.IsDone() {
-					out = append(out, *t)
-				}
-				break
-			}
-		}
-	}
-	return out
-}
-
-func FilterOverdue(tasks []task.Task, _ []string, _ string) []task.Task {
-	now := time.Now()
-	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	var out []task.Task
-	for i := range tasks {
-		t := &tasks[i]
-		if t.Due != nil && t.Due.Before(today) && !t.IsDone() {
-			out = append(out, *t)
-		}
-	}
-	return out
-}
-
-func FilterCalDAV(tasks []task.Task, _ []string, _ string) []task.Task {
+func FilterCalDAV(tasks []task.Task) []task.Task {
 	var out []task.Task
 	for i := range tasks {
 		if tasks[i].CalDAVUID != "" {
@@ -303,8 +257,134 @@ func FilterCalDAV(tasks []task.Task, _ []string, _ string) []task.Task {
 	return out
 }
 
-func sameDay(a, b time.Time) bool {
-	ay, am, ad := a.Date()
-	by, bm, bd := b.Date()
-	return ay == by && am == bm && ad == bd
+func MakeFolderFilter(vaultPath string, folders []string) FilterFunc {
+	return func(tasks []task.Task) []task.Task {
+		var out []task.Task
+		for i := range tasks {
+			for _, folder := range folders {
+				prefix := vaultPath + "/" + folder + "/"
+				if strings.HasPrefix(tasks[i].Source.FilePath, prefix) {
+					out = append(out, tasks[i])
+					break
+				}
+			}
+		}
+		return out
+	}
+}
+
+func MakeTimeWindowFilter(vaultPath string, folders []string, dailyFormat, window, weekStart string) FilterFunc {
+	startDay := time.Sunday
+	if strings.ToLower(weekStart) == "monday" {
+		startDay = time.Monday
+	}
+
+	return func(tasks []task.Task) []task.Task {
+		now := time.Now()
+		var begin, end time.Time
+
+		switch window {
+		case "week":
+			offset := int(now.Weekday()) - int(startDay)
+			if offset < 0 {
+				offset += 7
+			}
+			begin = time.Date(now.Year(), now.Month(), now.Day()-offset, 0, 0, 0, 0, now.Location())
+			end = begin.AddDate(0, 0, 7)
+		case "month":
+			begin = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+			end = begin.AddDate(0, 1, 0)
+		default:
+			return nil
+		}
+
+		return matchWindow(tasks, vaultPath, folders, dailyFormat, begin, end)
+	}
+}
+
+func MakeRollingFilter(vaultPath string, folders []string, dailyFormat string, days int) FilterFunc {
+	return func(tasks []task.Task) []task.Task {
+		now := time.Now()
+		begin := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		end := begin.AddDate(0, 0, days)
+		return matchWindow(tasks, vaultPath, folders, dailyFormat, begin, end)
+	}
+}
+
+func matchWindow(tasks []task.Task, vaultPath string, folders []string, dailyFormat string, begin, end time.Time) []task.Task {
+	var out []task.Task
+
+outer:
+	for i := range tasks {
+		t := &tasks[i]
+
+		if t.Due != nil && !t.Due.Before(begin) && t.Due.Before(end) {
+			out = append(out, *t)
+			continue
+		}
+
+		for _, folder := range folders {
+			prefix := vaultPath + "/" + folder + "/"
+			if !strings.HasPrefix(t.Source.FilePath, prefix) {
+				continue
+			}
+
+			base := strings.TrimSuffix(filepath.Base(t.Source.FilePath), ".md")
+			d, err := time.Parse(dailyFormat, base)
+			if err != nil {
+				continue
+			}
+
+			if !d.Before(begin) && d.Before(end) {
+				out = append(out, *t)
+				continue outer
+			}
+		}
+	}
+
+	return out
+}
+
+func MakeFileFilter(vaultPath, relFile string) FilterFunc {
+	abs := filepath.Join(vaultPath, relFile)
+	return func(tasks []task.Task) []task.Task {
+		var out []task.Task
+		for i := range tasks {
+			if tasks[i].Source.FilePath == abs {
+				out = append(out, tasks[i])
+			}
+		}
+		return out
+	}
+}
+
+func MakeTagFilter(tag string) FilterFunc {
+	tag = strings.TrimPrefix(tag, "#")
+	return func(tasks []task.Task) []task.Task {
+		var out []task.Task
+		for i := range tasks {
+			for _, tg := range tasks[i].Tags {
+				if tg == tag {
+					out = append(out, tasks[i])
+					break
+				}
+			}
+		}
+		return out
+	}
+}
+
+func MakeWikiLinkFilter(link string) FilterFunc {
+	return func(tasks []task.Task) []task.Task {
+		var out []task.Task
+		for i := range tasks {
+			for _, wl := range tasks[i].WikiLinks {
+				if wl == link {
+					out = append(out, tasks[i])
+					break
+				}
+			}
+		}
+		return out
+	}
 }

--- a/internal/vault/parser.go
+++ b/internal/vault/parser.go
@@ -81,6 +81,12 @@ func ParseTasks(filePath string) ([]task.Task, error) {
 		if frontmatter.due != nil {
 			t.Due = frontmatter.due
 		}
+		if frontmatter.dtstart != nil {
+			t.Start = frontmatter.dtstart
+		}
+		if frontmatter.rrule != "" {
+			t.RRule = frontmatter.rrule
+		}
 
 		tasks = append(tasks, t)
 	}
@@ -153,8 +159,12 @@ func ParseAllTasks(vaultPath, taskFilesFolder string) ([]task.Task, error) {
 		if fm.due != nil {
 			allTasks[i].Due = fm.due
 		}
+		if fm.dtstart != nil {
+			allTasks[i].Start = fm.dtstart
+		}
 		allTasks[i].Priority = fm.priority
 		allTasks[i].CalDAVStatus = fm.status
+		allTasks[i].RRule = fm.rrule
 		allTasks[i].Body = readTaskFileBody(taskFile)
 	}
 
@@ -182,8 +192,10 @@ func extractTags(s string) []string {
 type frontmatterData struct {
 	calDAVUID  string
 	due        *time.Time
+	dtstart    *time.Time
 	isTaskFile bool // true if frontmatter contains "type: task"
 	priority   int
+	rrule      string
 	status     string
 }
 
@@ -216,6 +228,12 @@ func parseFrontmatter(f *os.File) frontmatterData {
 			} else if t, err := time.Parse(time.RFC3339, value); err == nil {
 				data.due = &t
 			}
+		case "dtstart":
+			if t, err := time.Parse("2006-01-02", value); err == nil {
+				data.dtstart = &t
+			} else if t, err := time.Parse(time.RFC3339, value); err == nil {
+				data.dtstart = &t
+			}
 		case "type":
 			if value == "task" {
 				data.isTaskFile = true
@@ -224,6 +242,8 @@ func parseFrontmatter(f *os.File) frontmatterData {
 			if p, err := strconv.Atoi(value); err == nil {
 				data.priority = p
 			}
+		case "rrule":
+			data.rrule = value
 		case "status":
 			data.status = value
 		}

--- a/internal/vault/parser_test.go
+++ b/internal/vault/parser_test.go
@@ -63,7 +63,9 @@ func TestParseFrontmatter(t *testing.T) {
 	content := `---
 type: task
 title: "deploy fix"
+dtstart: 2026-03-30
 due: 2026-04-01
+rrule: FREQ=WEEKLY
 caldav-uid: abc-123
 ---
 
@@ -88,6 +90,12 @@ caldav-uid: abc-123
 	}
 	if tasks[0].Due.Format("2006-01-02") != "2026-04-01" {
 		t.Errorf("due = %v", tasks[0].Due)
+	}
+	if tasks[0].Start == nil || tasks[0].Start.Format("2006-01-02") != "2026-03-30" {
+		t.Errorf("start = %v", tasks[0].Start)
+	}
+	if tasks[0].RRule != "FREQ=WEEKLY" {
+		t.Errorf("rrule = %q", tasks[0].RRule)
 	}
 }
 

--- a/internal/vault/writer.go
+++ b/internal/vault/writer.go
@@ -173,7 +173,7 @@ func EnsureTaskFolder(vaultPath, folder string) (string, string) {
 
 // CreateTaskFile writes a task file at folderPath/<uid>.md with YAML frontmatter,
 // a title header, and an optional description body.
-func CreateTaskFile(folderPath, uid, title, description string, due *time.Time, priority int, status string) error {
+func CreateTaskFile(folderPath, uid, title, description string, start, due *time.Time, rrule string, priority int, status string) error {
 	if status == "" {
 		status = "NEEDS-ACTION"
 	}
@@ -182,8 +182,14 @@ func CreateTaskFile(folderPath, uid, title, description string, due *time.Time, 
 	b.WriteString("---\n")
 	b.WriteString("type: task\n")
 	fmt.Fprintf(&b, "caldav-uid: %s\n", uid)
+	if start != nil {
+		b.WriteString("dtstart: " + start.Format(time.RFC3339) + "\n")
+	}
 	if due != nil {
 		b.WriteString("due: " + due.Format(time.RFC3339) + "\n")
+	}
+	if rrule != "" {
+		fmt.Fprintf(&b, "rrule: %s\n", rrule)
 	}
 	if priority > 0 {
 		fmt.Fprintf(&b, "priority: %d\n", priority)
@@ -250,7 +256,7 @@ func UpdateTaskFileStatus(filePath, status string) error {
 }
 
 // UpdateTaskFileFrontmatter overwrites due/status/priority fields in a task file's frontmatter.
-func UpdateTaskFileFrontmatter(filePath string, due *time.Time, status string, priority int) error {
+func UpdateTaskFileFrontmatter(filePath string, start, due *time.Time, rrule, status string, priority int) error {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("reading %s: %w", filePath, err)
@@ -272,7 +278,7 @@ func UpdateTaskFileFrontmatter(filePath string, due *time.Time, status string, p
 		return nil
 	}
 
-	updatedDue, updatedStatus, updatedPriority := false, false, false
+	updatedStart, updatedDue, updatedRRule, updatedStatus, updatedPriority := false, false, false, false, false
 
 	// First pass: update or remove existing fields.
 	// Build filtered lines to handle removals (due=nil clears the field, priority=0 clears it).
@@ -291,6 +297,16 @@ func UpdateTaskFileFrontmatter(filePath string, due *time.Time, status string, p
 				filtered = append(filtered, "due: "+due.Format(time.RFC3339))
 			}
 			// due==nil: omit the line (clear due date)
+		case "dtstart":
+			updatedStart = true
+			if start != nil {
+				filtered = append(filtered, "dtstart: "+start.Format(time.RFC3339))
+			}
+		case "rrule":
+			updatedRRule = true
+			if rrule != "" {
+				filtered = append(filtered, "rrule: "+rrule)
+			}
 		case "status":
 			updatedStatus = true
 			if status != "" {
@@ -310,8 +326,14 @@ func UpdateTaskFileFrontmatter(filePath string, due *time.Time, status string, p
 	}
 
 	// Insert missing fields before closing ---
+	if !updatedStart && start != nil {
+		filtered = append(filtered, "dtstart: "+start.Format(time.RFC3339))
+	}
 	if !updatedDue && due != nil {
 		filtered = append(filtered, "due: "+due.Format(time.RFC3339))
+	}
+	if !updatedRRule && rrule != "" {
+		filtered = append(filtered, "rrule: "+rrule)
 	}
 	if !updatedStatus && status != "" {
 		filtered = append(filtered, "status: "+status)
@@ -328,7 +350,7 @@ func UpdateTaskFileFrontmatter(filePath string, due *time.Time, status string, p
 
 // UpdateTaskFileContent updates title, body, and frontmatter fields (due/status/priority)
 // in a single read-modify-write pass.
-func UpdateTaskFileContent(filePath, title, body string, due *time.Time, status string, priority int) error {
+func UpdateTaskFileContent(filePath, title, body string, start, due *time.Time, rrule, status string, priority int) error {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("reading %s: %w", filePath, err)
@@ -352,7 +374,7 @@ func UpdateTaskFileContent(filePath, title, body string, due *time.Time, status 
 	}
 
 	// Rewrite frontmatter fields
-	updatedDue, updatedStatus, updatedPriority := false, false, false
+	updatedStart, updatedDue, updatedRRule, updatedStatus, updatedPriority := false, false, false, false, false
 	filtered := make([]string, 0, len(lines))
 	filtered = append(filtered, lines[0])
 	for i := 1; i < closingIdx; i++ {
@@ -362,10 +384,20 @@ func UpdateTaskFileContent(filePath, title, body string, due *time.Time, status 
 			continue
 		}
 		switch key {
+		case "dtstart":
+			updatedStart = true
+			if start != nil {
+				filtered = append(filtered, "dtstart: "+start.Format(time.RFC3339))
+			}
 		case "due":
 			updatedDue = true
 			if due != nil {
 				filtered = append(filtered, "due: "+due.Format(time.RFC3339))
+			}
+		case "rrule":
+			updatedRRule = true
+			if rrule != "" {
+				filtered = append(filtered, "rrule: "+rrule)
 			}
 		case "status":
 			updatedStatus = true
@@ -383,8 +415,14 @@ func UpdateTaskFileContent(filePath, title, body string, due *time.Time, status 
 			filtered = append(filtered, lines[i])
 		}
 	}
+	if !updatedStart && start != nil {
+		filtered = append(filtered, "dtstart: "+start.Format(time.RFC3339))
+	}
 	if !updatedDue && due != nil {
 		filtered = append(filtered, "due: "+due.Format(time.RFC3339))
+	}
+	if !updatedRRule && rrule != "" {
+		filtered = append(filtered, "rrule: "+rrule)
 	}
 	if !updatedStatus && status != "" {
 		filtered = append(filtered, "status: "+status)

--- a/internal/vault/writer_test.go
+++ b/internal/vault/writer_test.go
@@ -272,3 +272,25 @@ func TestWriteFrontmatterUID_SkipsNoFrontmatter(t *testing.T) {
 		t.Errorf("expected no caldav-uid written to file without frontmatter, got:\n%s", string(data))
 	}
 }
+
+func TestCreateTaskFile_WritesStartAndRRule(t *testing.T) {
+	dir := t.TempDir()
+	start := time.Date(2026, 3, 30, 9, 0, 0, 0, time.UTC)
+	due := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+
+	if err := CreateTaskFile(dir, "uid-1", "Title", "Body", &start, &due, "FREQ=WEEKLY", 5, "NEEDS-ACTION"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "uid-1.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "dtstart: 2026-03-30T09:00:00Z") {
+		t.Fatalf("missing dtstart in file:\n%s", s)
+	}
+	if !strings.Contains(s, "rrule: FREQ=WEEKLY") {
+		t.Fatalf("missing rrule in file:\n%s", s)
+	}
+}

--- a/sync.md
+++ b/sync.md
@@ -112,13 +112,25 @@ Parser hydrates UID, due, status, priority by resolving wikilinks to task files.
 
 ---
 
-## Due Date Fields in Add Form
+## Start, Due, and Repeat Fields in Forms
 
-Two separate fields:
-- `Due date:  [2026-04-02]`
-- `Due time:  [15:30     ]` (optional — if empty, sends date-only VTODO)
+The add/edit forms support:
+- `Start date: [2026-04-01]`
+- `Start time: [09:00     ]` (optional — if empty, sends date-only DTSTART)
+- `Due date:   [2026-04-02]`
+- `Due time:   [15:30     ]` (optional — if empty, sends date-only DUE)
+- `Repeat:     [none|daily|weekly|monthly|yearly]`
 
-Same pattern for start date/time (future — tracked in todo.md).
+Repeat values map to RRULE:
+- `daily` -> `FREQ=DAILY`
+- `weekly` -> `FREQ=WEEKLY`
+- `monthly` -> `FREQ=MONTHLY`
+- `yearly` -> `FREQ=YEARLY`
+
+Task file frontmatter persists this as:
+- `dtstart: <RFC3339>`
+- `due: <RFC3339>`
+- `rrule: FREQ=...`
 
 ---
 

--- a/todo.md
+++ b/todo.md
@@ -46,10 +46,16 @@ Add Cobra for CLI framework, then implement:
 - [x] CalDAV pull (`R` key): REPORT all VTODOs, update existing task file frontmatter, create new task files + inbox entries for remote-only tasks; auto-reload after pull
 - [x] toggle linked tasks: checkbox flip updates task file status + pushes to CalDAV; error shown in status bar if push fails
 - [x] `p` key: open add form pre-filled with task description, on submit rewrite plain task line to `[[uid|title]]` wikilink and create task file
+- [ ] add right-side stats overview panel (OpenCode-style) in browser view
+  - implement stats aggregator: total/open/done/done%, overdue/today/next 7d/no due, CalDAV linked/unlinked, top tags/files
+  - responsive layout: auto-hide stats panel on narrow terminals (< 110 cols)
+  - add toggle key for stats panel visibility (e.g., `s`)
+  - stats computed from all vault tasks (global) + current tab counts
 - [ ] task detail view: press `d` to render `tasks/<uid>.md` content as preview overlay (see sync.md)
 - [ ] open task source in Obsidian: press `o` to launch `obsidian://open?vault=...&file=...` URI — opens the note in the Obsidian app directly from Obia (works from WSL via Windows interop)
 - [ ] add form: upgrade Description field from single-line input to multi-line textarea
-- [ ] CalDAV: add `DTSTART` (start date) support
+- [x] CalDAV: add `DTSTART` (start date) support
+- [x] add repeat option in add/edit forms (`none`, `daily`, `weekly`, `monthly`, `yearly`) with RRULE sync
 
 ## Bugs
 


### PR DESCRIPTION
## Summary

- Add `Start` and `RRule` fields to `Task` model
- Add **Start date/time** and **Repeat** selector to add/edit forms:
  - Repeat options: `none`, `daily`, `weekly`, `monthly`, `yearly`
  - Maps to iCalendar `RRULE` values: `FREQ=DAILY`, `FREQ=WEEKLY`, etc.
- Persist `dtstart` and `rrule` in task file YAML frontmatter
- Emit `DTSTART` and `RRULE` in CalDAV VTODO push payloads
- Parse `DTSTART` and `RRULE` on CalDAV pull and hydrate into task files
- Add tests for new fields across parser, writer, and CalDAV modules
- Update documentation (README, sync.md, todo.md)

## Testing

- `go test ./...` passes
- Manual testing: create/edit recurring tasks, verify frontmatter, push/pull from CalDAV

## Example Task File

```markdown
---
type: task
caldav-uid: ...
dtstart: 2026-04-01T09:00:00Z
due: 2026-04-02T09:00:00Z
rrule: FREQ=WEEKLY
priority: 5
status: NEEDS-ACTION
---
```